### PR TITLE
disable selinux

### DIFF
--- a/centos/centos-7.x/centos-7.6-hpc/configure_selinux.sh
+++ b/centos/centos-7.x/centos-7.6-hpc/configure_selinux.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+../../common/configure_selinux.sh
+

--- a/centos/centos-7.x/centos-7.7-hpc/configure_selinux.sh
+++ b/centos/centos-7.x/centos-7.7-hpc/configure_selinux.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+../../common/configure_selinux.sh
+

--- a/centos/centos-8.x/centos-8.1-hpc/configure_selinux.sh
+++ b/centos/centos-8.x/centos-8.1-hpc/configure_selinux.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+../../common/configure_selinux.sh
+

--- a/centos/common/configure_selinux.sh
+++ b/centos/common/configure_selinux.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sed -i 's/^SELINUX=enforcing/SELINUX=disabled/g' /etc/selinux/config


### PR DESCRIPTION
Disable selinux on all CentOS images to avoid thorny security challenges, such as setting up shared /home directories in HPC clusters.