### PR TITLE
Adds Azure HPC Diagnostics Tool

### DIFF
--- a/centos/centos-7.x/centos-7.6-hpc/README.md
+++ b/centos/centos-7.x/centos-7.6-hpc/README.md
@@ -18,6 +18,7 @@ consistency, and reliability. This image consists of the following HPC tools and
   - AMD FFTW
   - AMD Flame
   - Intel MKL
+- Azure HPC Diagnostics Tool
 
 Software packages are configured as environment modules. Users can select preferred MPI or software packages as follows:
 

--- a/centos/centos-7.x/centos-7.6-hpc/install.sh
+++ b/centos/centos-7.x/centos-7.6-hpc/install.sh
@@ -30,3 +30,6 @@ $COMMON_DIR/copy_test_file.sh
 
 # lustre client
 #./install_lustre_client.sh
+
+# install diagnostic script
+"$COMMON_DIR/install_hpcdiag.sh"

--- a/centos/centos-7.x/centos-7.7-hpc/README.md
+++ b/centos/centos-7.x/centos-7.7-hpc/README.md
@@ -18,6 +18,7 @@ consistency, and reliability. This image consists of the following HPC tools and
   - AMD FFTW
   - AMD Flame
   - Intel MKL
+- Azure HPC Diagnostics Tool
 
 Software packages are configured as environment modules. Users can select preferred MPI or software packages as follows:
 

--- a/centos/centos-7.x/centos-7.7-hpc/install.sh
+++ b/centos/centos-7.x/centos-7.7-hpc/install.sh
@@ -30,3 +30,6 @@ $COMMON_DIR/copy_test_file.sh
 
 # lustre client
 #./install_lustre_client.sh
+
+# install diagnostic script
+"$COMMON_DIR/install_hpcdiag.sh"

--- a/centos/centos-7.x/centos-7.8-hpc/README.md
+++ b/centos/centos-7.x/centos-7.8-hpc/README.md
@@ -18,6 +18,7 @@ consistency, and reliability. This image consists of the following HPC tools and
   - AMD FFTW
   - AMD Flame
   - Intel MKL
+- Azure HPC Diagnostics Tool
 
 Software packages are configured as environment modules. Users can select preferred MPI or software packages as follows:
 

--- a/centos/centos-7.x/centos-7.8-hpc/install.sh
+++ b/centos/centos-7.x/centos-7.8-hpc/install.sh
@@ -30,3 +30,6 @@ $COMMON_DIR/copy_test_file.sh
 
 # lustre client
 #./install_lustre_client.sh
+
+# install diagnostic script
+"$COMMON_DIR/install_hpcdiag.sh"

--- a/centos/centos-8.x/centos-8.1-hpc/README.md
+++ b/centos/centos-8.x/centos-8.1-hpc/README.md
@@ -18,6 +18,7 @@ consistency, and reliability. This image consists of the following HPC tools and
   - AMD FFTW
   - AMD Flame
   - Intel MKL
+- Azure HPC Diagnostics Tool
 
 Software packages are configured as environment modules. Users can select preferred MPI or software packages as follows:
 

--- a/centos/centos-8.x/centos-8.1-hpc/install.sh
+++ b/centos/centos-8.x/centos-8.1-hpc/install.sh
@@ -27,3 +27,6 @@ source ./set_properties.sh
 
 # copy test file
 $COMMON_DIR/copy_test_file.sh
+
+# install diagnostic script
+"$COMMON_DIR/install_hpcdiag.sh"

--- a/common/install_hpcdiag.sh
+++ b/common/install_hpcdiag.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+
+DESTINATION_DIR='/opt/azurehpc/diagnostics'
+LATEST_RELEASE_API_URL="https://api.github.com/repos/Azure/azhpc-diagnostics/releases/latest"
+
+# example (after grep): 
+# "tarball_url": "https://api.github.com/repos/Azure/azhpc-diagnostics/tarball/hpcdiag-20201201",
+DOWNLOAD_URL=$(curl -s "$LATEST_RELEASE_API_URL" | grep 'tarball_url' | cut -d\" -f4)
+
+# not using download_and_verify.sh because github doesn't provide a checksum
+wget "$DOWNLOAD_URL"
+DOWNLOADED_FILE_NAME=$(basename "$DOWNLOAD_URL")
+
+TARBALL_FILES=$(tar -xzvf "$DOWNLOADED_FILE_NAME")
+UNPACK_DIR=$(echo "$TARBALL_FILES" | head -1)
+
+sudo mkdir -p "$DESTINATION_DIR"
+sudo cp "$UNPACK_DIR/Linux/src/gather_azhpc_vm_diagnostics.sh" "$DESTINATION_DIR"
+
+rm -r "$DOWNLOADED_FILE_NAME" "$UNPACK_DIR"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -189,6 +189,9 @@ check_exists "${MODULE_FILES_ROOT}/gcc-${GCC_VERSION}"
 check_exists "/opt/gcc-${GCC_VERSION}/"
 check_exists "/opt/intel/compilers_and_libraries_${MKL_VERSION}/linux/mkl/"
 
+# verify hpcdiag installation
+check_exists '/opt/azurehpc/diagnostics/gather_azhpc_vm_diagnostics.sh'
+
 if [ $CHECK_AOCL -eq 1 ]
 then
     # verify AMD modulefiles

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/README.md
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/README.md
@@ -19,6 +19,7 @@ consistency, and reliability. This image consists of the following HPC tools and
   - Intel MKL
 - GPU Drivers
   - Nvidia GPU Driver
+- Azure HPC Diagnostics Tool
 
 Software packages are configured as environment modules. Users can select preferred MPI or software packages as follows:
 

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 set -ex
 
@@ -32,3 +31,6 @@ rm -Rf -- */
 
 # copy test file
 $COMMON_DIR/copy_test_file.sh
+
+# install diagnostic script
+"$COMMON_DIR/install_hpcdiag.sh"


### PR DESCRIPTION
This PR adds a script called install_hpcdiag.sh to the common directory.

The script is called by each install.sh, and when invoked it fetches the latest release of the Azure HPC Diagnostics Tool from GitHub and copies it to /opt/azurehpc/diagnostics.

This branch has been run through the testing pipeline.