### PR TITLE
Disabling Nvidia Cuda Install

### DIFF
--- a/centos/centos-7.x/centos-7.6-hpc/install.sh
+++ b/centos/centos-7.x/centos-7.6-hpc/install.sh
@@ -17,7 +17,7 @@ source ./set_properties.sh
 ./install_mpis.sh
 
 # install nvidia gpu driver
-./install_nvidiagpudriver.sh
+#./install_nvidiagpudriver.sh
 
 # install AMD tuned libraries
 ./install_amd_libs.sh

--- a/centos/centos-7.x/centos-7.7-hpc/install.sh
+++ b/centos/centos-7.x/centos-7.7-hpc/install.sh
@@ -17,7 +17,7 @@ source ./set_properties.sh
 ./install_mpis.sh
 
 # install nvidia gpu driver
-./install_nvidiagpudriver.sh
+#./install_nvidiagpudriver.sh
 
 # install AMD tuned libraries
 ./install_amd_libs.sh

--- a/centos/centos-7.x/centos-7.8-hpc/install.sh
+++ b/centos/centos-7.x/centos-7.8-hpc/install.sh
@@ -17,7 +17,7 @@ source ./set_properties.sh
 ./install_mpis.sh
 
 # install nvidia gpu driver
-./install_nvidiagpudriver.sh
+#./install_nvidiagpudriver.sh
 
 # install AMD tuned libraries
 ./install_amd_libs.sh

--- a/centos/centos-8.x/centos-8.1-hpc/install.sh
+++ b/centos/centos-8.x/centos-8.1-hpc/install.sh
@@ -17,7 +17,7 @@ source ./set_properties.sh
 ./install_mpis.sh
 
 # install nvidia gpu driver
-./install_nvidiagpudriver.sh
+#./install_nvidiagpudriver.sh
 
 # install AMD tuned libraries
 ./install_amd_libs.sh


### PR DESCRIPTION
Disabling Nvidia Cuda Install for CentsOS 8.1, 7.8, 7.7, 7.6 and Ubuntu 18.04.