### PR TITLE
skip IB eth device config, avoid 30s timeout

### DIFF
--- a/centos/centos-7.x/centos-7.6-hpc/install.sh
+++ b/centos/centos-7.x/centos-7.6-hpc/install.sh
@@ -28,6 +28,9 @@ source ./set_properties.sh
 # add udev rule
 $COMMON_DIR/../centos/common/add-udev-rules.sh
 
+# add interface rules
+$COMMON_DIR/../centos/common/network-config.sh
+
 # optimizations
 ./hpc-tuning.sh
 

--- a/centos/centos-7.x/centos-7.7-hpc/install.sh
+++ b/centos/centos-7.x/centos-7.7-hpc/install.sh
@@ -28,6 +28,9 @@ source ./set_properties.sh
 # add udev rule
 $COMMON_DIR/../centos/common/add-udev-rules.sh
 
+# add interface rules
+$COMMON_DIR/../centos/common/network-config.sh
+
 # optimizations
 ./hpc-tuning.sh
 

--- a/centos/centos-7.x/centos-7.8-hpc/install.sh
+++ b/centos/centos-7.x/centos-7.8-hpc/install.sh
@@ -28,6 +28,9 @@ source ./set_properties.sh
 # add udev rule
 $COMMON_DIR/../centos/common/add-udev-rules.sh
 
+# add interface rules
+$COMMON_DIR/../centos/common/network-config.sh
+
 # optimizations
 ./hpc-tuning.sh
 

--- a/centos/centos-8.x/centos-8.1-hpc/install.sh
+++ b/centos/centos-8.x/centos-8.1-hpc/install.sh
@@ -28,6 +28,9 @@ source ./set_properties.sh
 # add udev rule
 $COMMON_DIR/../centos/common/add-udev-rules.sh
 
+# add interface rules
+$COMMON_DIR/../centos/common/network-config.sh
+
 # optimizations
 ./hpc-tuning.sh
 

--- a/centos/common/network-config.sh
+++ b/centos/common/network-config.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+sed -i '/\[main\]/a no-auto-default=*' /etc/NetworkManager/NetworkManager.conf
+
+# update network config on reboot
+mkdir -p /lib/systemd/system/cloud-init-local.service.d/
+cat <<EOF > /lib/systemd/system/cloud-init-local.service.d/50-azure-clear-persistent-obj-pkl.conf
+[Service]
+ExecStartPre=-/bin/sh -xc 'if [ -e /var/lib/cloud/instance/obj.pkl ]; then echo "cleaning persistent cloud-init object"; rm /var/lib/cloud/instance/obj.pkl; fi; exit 0'
+EOF


### PR DESCRIPTION
RougueWave/OpenLogic CentOS NetworkManager will dynamically configure all eth network adapters. On the IB device (typically eth1) this will cause a 30s delay as the address update times out and will delay the VM provisioning - affecting TDPR.