### PR TITLE
Adding support for CentOS 8.3

### DIFF
--- a/centos/centos-8.x/centos-8.3-hpc/README.md
+++ b/centos/centos-8.x/centos-8.3-hpc/README.md
@@ -1,0 +1,25 @@
+# CentOS 8.1 HPC Image
+
+The CentOS 8.3 HPC Image includes optimizations and recommended configurations to deliver optimal performance,
+consistency, and reliability. This image consists of the following HPC tools and libraries:
+
+- Mellanox OFED
+- Pre-configured IPoIB (IP-over-InfiniBand)
+- Popular InfiniBand based MPI Libraries
+  - HPC-X
+  - IntelMPI
+  - MVAPICH2
+  - OpenMPI
+- Communication Runtimes
+  - Libfabric
+  - OpenUCX
+- Optimized librares
+  - AMD Blis
+  - AMD FFTW
+  - AMD Flame
+  - Intel MKL
+- Azure HPC Diagnostics Tool
+
+Software packages are configured as environment modules. Users can select preferred MPI or software packages as follows:
+
+`module load <package-name>`

--- a/centos/centos-8.x/centos-8.3-hpc/hpc-tuning.sh
+++ b/centos/centos-8.x/centos-8.3-hpc/hpc-tuning.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+../../common/hpc-tuning.sh
+

--- a/centos/centos-8.x/centos-8.3-hpc/install.sh
+++ b/centos/centos-8.x/centos-8.3-hpc/install.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -ex
+
+# set properties
+source ./set_properties.sh
+
+# install utils
+./install_utils.sh
+
+# install compilers
+./install_gcc.sh
+
+# install mellanox ofed
+./install_mellanoxofed.sh
+
+# install mpi libraries
+./install_mpis.sh
+
+# install nvidia gpu driver
+#./install_nvidiagpudriver.sh
+
+# install AMD tuned libraries
+./install_amd_libs.sh
+
+# install Intel libraries
+./install_intel_libs.sh
+
+# add udev rule
+$COMMON_DIR/../centos/common/add-udev-rules.sh
+
+# add interface rules
+$COMMON_DIR/../centos/common/network-config.sh
+
+# optimizations
+./hpc-tuning.sh
+
+# copy test file
+$COMMON_DIR/copy_test_file.sh
+
+# install diagnostic script
+"$COMMON_DIR/install_hpcdiag.sh"

--- a/centos/centos-8.x/centos-8.3-hpc/install_amd_libs.sh
+++ b/centos/centos-8.x/centos-8.3-hpc/install_amd_libs.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$COMMON_DIR/../centos/centos-8.x/common/install_amd_libs.sh

--- a/centos/centos-8.x/centos-8.3-hpc/install_gcc.sh
+++ b/centos/centos-8.x/centos-8.3-hpc/install_gcc.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+MODULE_FILES_DIRECTORY=/usr/share/Modules/modulefiles
+
+mkdir -p ${MODULE_FILES_DIRECTORY}
+
+$COMMON_DIR/install_gcc-9.2.sh ${MODULE_FILES_DIRECTORY}

--- a/centos/centos-8.x/centos-8.3-hpc/install_intel_libs.sh
+++ b/centos/centos-8.x/centos-8.3-hpc/install_intel_libs.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+$COMMON_DIR/install_intel_libs.sh
+

--- a/centos/centos-8.x/centos-8.3-hpc/install_mellanoxofed.sh
+++ b/centos/centos-8.x/centos-8.3-hpc/install_mellanoxofed.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -ex
+
+MLNX_OFED_DOWNLOAD_URL=https://azhpcstor.blob.core.windows.net/azhpc-images-store/MLNX_OFED_LINUX-5.2-1.0.4.0-rhel8.3-x86_64.tgz
+TARBALL=$(basename ${MLNX_OFED_DOWNLOAD_URL})
+MOFED_FOLDER=$(basename ${MLNX_OFED_DOWNLOAD_URL} .tgz)
+
+$COMMON_DIR/download_and_verify.sh $MLNX_OFED_DOWNLOAD_URL "dd13ffa54524af9509e3de7288a863aa48ed7016bb3d15446523703020c41715"
+tar zxvf ${TARBALL}
+
+KERNEL=( $(rpm -q kernel | sed 's/kernel\-//g') )
+KERNEL=${KERNEL[-1]}
+yum install -y kernel-devel-${KERNEL}
+./${MOFED_FOLDER}/mlnxofedinstall --kernel $KERNEL --kernel-sources /usr/src/kernels/${KERNEL} --add-kernel-support --skip-repo
+

--- a/centos/centos-8.x/centos-8.3-hpc/install_mpis.sh
+++ b/centos/centos-8.x/centos-8.3-hpc/install_mpis.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -ex
+
+# Load gcc
+GCC_VERSION=gcc-9.2.0
+export PATH=/opt/${GCC_VERSION}/bin:$PATH
+export LD_LIBRARY_PATH=/opt/${GCC_VERSION}/lib64:$LD_LIBRARY_PATH
+set CC=/opt/${GCC_VERSION}/bin/gcc
+set GCC=/opt/${GCC_VERSION}/bin/gcc
+
+
+INSTALL_PREFIX=/opt
+
+# HPC-X v2.7.4
+HPCX_VERSION="v2.7.4"
+HPCX_DOWNLOAD_URL=https://azhpcstor.blob.core.windows.net/azhpc-images-store/hpcx-v2.8.0-gcc-MLNX_OFED_LINUX-5.2-1.0.4.0-redhat8.3-x86_64.tbz
+TARBALL=$(basename ${HPCX_DOWNLOAD_URL})
+HPCX_FOLDER=$(basename ${HPCX_DOWNLOAD_URL} .tbz)
+
+$COMMON_DIR/download_and_verify.sh $HPCX_DOWNLOAD_URL "ee1b0f3fe8d295ae662cd08794a890135b4014b9b3e8efa3f00aafe4678bae9c"
+tar -xvf ${TARBALL}
+mv ${HPCX_FOLDER} ${INSTALL_PREFIX}
+HPCX_PATH=${INSTALL_PREFIX}/${HPCX_FOLDER}
+
+# Setup module files for MPIs
+mkdir -p /usr/share/Modules/modulefiles/mpi/
+
+# HPC-X
+cat << EOF >> /usr/share/Modules/modulefiles/mpi/hpcx-${HPCX_VERSION}
+#%Module 1.0
+#
+#  HPCx ${HPCX_VERSION}
+#
+conflict        mpi
+module load ${HPCX_PATH}/modulefiles/hpcx
+EOF
+
+# Create symlinks for modulefiles
+ln -s /usr/share/Modules/modulefiles/mpi/hpcx-${HPCX_VERSION} /usr/share/Modules/modulefiles/mpi/hpcx
+
+# Install platform independent MPIs
+../../common/install_mpis.sh ${GCC_VERSION} ${HPCX_PATH}

--- a/centos/centos-8.x/centos-8.3-hpc/install_utils.sh
+++ b/centos/centos-8.x/centos-8.3-hpc/install_utils.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+../common/install_utils.sh
+

--- a/centos/centos-8.x/centos-8.3-hpc/set_properties.sh
+++ b/centos/centos-8.x/centos-8.3-hpc/set_properties.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export TOP_DIR=../../..
+export COMMON_DIR=../../../common
+export TEST_DIR=../../../tests

--- a/centos/common/network-config.sh
+++ b/centos/common/network-config.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 
 sed -i '/\[main\]/a no-auto-default=*' /etc/NetworkManager/NetworkManager.conf
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,3 +1,4 @@
+
 #!/bin/bash
 source /etc/profile
 
@@ -11,6 +12,7 @@ HPCX_OMB_PATH_CENTOS_76="/opt/hpcx-v2.7.4-gcc-${CENTOS_MOFED_VERSION}-redhat7.6-
 HPCX_OMB_PATH_CENTOS_77="/opt/hpcx-v2.7.4-gcc-${CENTOS_MOFED_VERSION}-redhat7.7-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
 HPCX_OMB_PATH_CENTOS_78="/opt/hpcx-v2.7.4-gcc-${CENTOS_MOFED_VERSION}-redhat7.8-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
 HPCX_OMB_PATH_CENTOS_81="/opt/hpcx-v2.7.4-gcc-${CENTOS_MOFED_VERSION}-redhat8.1-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
+HPCX_OMB_PATH_CENTOS_83="/opt/hpcx-v2.8.0-gcc-${CENTOS_MOFED_VERSION}-redhat8.3-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
 CENTOS_MODULE_FILES_ROOT="/usr/share/Modules/modulefiles"
 CENTOS_IMPI2021_PATH="/opt/intel/oneapi/mpi/2021.1.1"
 CENTOS_MVAPICH2_PATH="/opt/mvapich2-2.3.5"
@@ -114,6 +116,20 @@ then
 elif [[ $distro == "CentOS Linux 8.1.1911" ]]
 then
     HPCX_OMB_PATH=${HPCX_OMB_PATH_CENTOS_81}
+    CHECK_HPCX=1
+    CHECK_IMPI_2021=1
+    CHECK_OMPI=1
+    CHECK_MVAPICH2=1
+    CHECK_MVAPICH2X=0
+    MODULE_FILES_ROOT=${CENTOS_MODULE_FILES_ROOT}
+    MOFED_VERSION=${CENTOS_MOFED_VERSION}
+    IMPI2021_PATH=${CENTOS_IMPI2021_PATH}
+    MVAPICH2_PATH=${CENTOS_MVAPICH2_PATH}
+    MVAPICH2X_PATH=${CENTOS_MVAPICH2X_PATH}
+    OPENMPI_PATH=${CENTOS_OPENMPI_PATH}
+elif [[ $distro == "CentOS Linux 8.3.2011" ]]
+then
+    HPCX_OMB_PATH=${HPCX_OMB_PATH_CENTOS_83}
     CHECK_HPCX=1
     CHECK_IMPI_2021=1
     CHECK_OMPI=1


### PR DESCRIPTION
Adding support for CentOS 8.3.

Updating permissions on /centos/common/network-config.sh

Tested on Standard_HC44rs.

Notes - Kernel should be updated to the latest version because the default repo only contains kernel-devel for the latest kernel version.