### PR TITLE
Fix persistent rdma naming

### DIFF
--- a/centos/centos-7.x/centos-7.6-hpc/install.sh
+++ b/centos/centos-7.x/centos-7.6-hpc/install.sh
@@ -42,3 +42,6 @@ $COMMON_DIR/copy_test_file.sh
 
 # install diagnostic script
 "$COMMON_DIR/install_hpcdiag.sh"
+
+# install persistent rdma naming
+$COMMON_DIR/install_azure_persistent_rdma_naming.sh

--- a/centos/centos-7.x/centos-7.7-hpc/install.sh
+++ b/centos/centos-7.x/centos-7.7-hpc/install.sh
@@ -42,3 +42,6 @@ $COMMON_DIR/copy_test_file.sh
 
 # install diagnostic script
 "$COMMON_DIR/install_hpcdiag.sh"
+
+# install persistent rdma naming
+$COMMON_DIR/install_azure_persistent_rdma_naming.sh

--- a/centos/centos-7.x/centos-7.8-hpc/install.sh
+++ b/centos/centos-7.x/centos-7.8-hpc/install.sh
@@ -42,3 +42,6 @@ $COMMON_DIR/copy_test_file.sh
 
 # install diagnostic script
 "$COMMON_DIR/install_hpcdiag.sh"
+
+# install persistent rdma naming
+$COMMON_DIR/install_azure_persistent_rdma_naming.sh

--- a/centos/centos-7.x/common/install_utils.sh
+++ b/centos/centos-7.x/common/install_utils.sh
@@ -26,4 +26,6 @@ yum install -y numactl \
     kernel-headers \
     nfs-utils \
     fuse-libs \
-    libpciaccess
+    libpciaccess \
+    cmake \
+    libnl3-devel

--- a/centos/centos-8.x/centos-8.1-hpc/install.sh
+++ b/centos/centos-8.x/centos-8.1-hpc/install.sh
@@ -39,3 +39,6 @@ $COMMON_DIR/copy_test_file.sh
 
 # install diagnostic script
 "$COMMON_DIR/install_hpcdiag.sh"
+
+# install persistent rdma naming
+$COMMON_DIR/install_azure_persistent_rdma_naming.sh

--- a/centos/centos-8.x/centos-8.3-hpc/install.sh
+++ b/centos/centos-8.x/centos-8.3-hpc/install.sh
@@ -39,3 +39,6 @@ $COMMON_DIR/copy_test_file.sh
 
 # install diagnostic script
 "$COMMON_DIR/install_hpcdiag.sh"
+
+# install persistent rdma naming
+$COMMON_DIR/install_azure_persistent_rdma_naming.sh

--- a/centos/centos-8.x/common/install_utils.sh
+++ b/centos/centos-8.x/common/install_utils.sh
@@ -27,4 +27,6 @@ yum install -y numactl \
     kernel-headers \
     nfs-utils \
     fuse-libs \
-    libpciaccess
+    libpciaccess \
+    cmake \
+    libnl3-devel

--- a/common/install_azure_persistent_rdma_naming.sh
+++ b/common/install_azure_persistent_rdma_naming.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -ex
+
+#
+# install rdma_rename with NAME_FIXED option
+#
+
+rdma_core_branch=stable-v34
+git clone -b $rdma_core_branch https://github.com/linux-rdma/rdma-core.git
+pushd rdma-core
+bash build.sh
+cp build/bin/rdma_rename /usr/sbin/rdma_rename_$rdma_core_branch
+popd
+rm -rf rdma-core
+
+#
+# setup systemd service
+#
+
+cat <<EOF >/usr/sbin/azure_persistent_rdma_naming.sh
+#!/bin/bash
+
+rdma_rename=/usr/lib/udev/rdma_rename_${rdma_core_branch}
+
+an_index=0
+ib_index=0
+
+for old_device in \$(ibdev2netdev -v | sort -n | cut -f2 -d' '); do
+
+	link_layer=\$(ibv_devinfo -d \$old_device | sed -n 's/^[\ \t]*link_layer:[\ \t]*\([a-zA-Z]*\)\$/\1/p')
+	
+	if [ "\$link_layer" = "InfiniBand" ]; then
+		
+		\$rdma_rename \$old_device NAME_FIXED mlx_ib\${ib_index}
+		ib_index=\$((\$ib_index + 1))
+		
+	elif [ "\$link_layer" = "Ethernet" ]; then
+	
+		\$rdma_rename \$old_device NAME_FIXED mlx_an\${an_index}
+		an_index=\$((\$an_index + 1))
+		
+	else
+	
+		echo "Unknown device type for \$old_device - \$device_type."
+		
+	fi
+	
+done
+EOF
+
+cat <<EOF >/etc/systemd/system/azure_persistent_rdma_naming.service
+[Unit]
+Description=Azure persistent RDMA naming
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/azure_persistent_rdma_naming.sh
+RemainAfterExit=true
+StandardOutput=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl enable azure_persistent_rdma_naming.service

--- a/common/install_azure_persistent_rdma_naming.sh
+++ b/common/install_azure_persistent_rdma_naming.sh
@@ -49,6 +49,7 @@ for old_device in \$(ibdev2netdev -v | sort -n | cut -f2 -d' '); do
 	
 done
 EOF
+chmod 755 /usr/sbin/azure_persistent_rdma_naming.sh
 
 cat <<EOF >/etc/systemd/system/azure_persistent_rdma_naming.service
 [Unit]

--- a/common/install_azure_persistent_rdma_naming.sh
+++ b/common/install_azure_persistent_rdma_naming.sh
@@ -5,6 +5,7 @@ set -ex
 # install rdma_rename with NAME_FIXED option
 #
 
+pushd /tmp
 rdma_core_branch=stable-v34
 git clone -b $rdma_core_branch https://github.com/linux-rdma/rdma-core.git
 pushd rdma-core
@@ -12,6 +13,7 @@ bash build.sh
 cp build/bin/rdma_rename /usr/sbin/rdma_rename_$rdma_core_branch
 popd
 rm -rf rdma-core
+popd
 
 #
 # setup systemd service

--- a/common/install_azure_persistent_rdma_naming.sh
+++ b/common/install_azure_persistent_rdma_naming.sh
@@ -22,7 +22,7 @@ popd
 cat <<EOF >/usr/sbin/azure_persistent_rdma_naming.sh
 #!/bin/bash
 
-rdma_rename=/usr/lib/udev/rdma_rename_${rdma_core_branch}
+rdma_rename=/usr/sbin/rdma_rename_${rdma_core_branch}
 
 an_index=0
 ib_index=0
@@ -33,12 +33,12 @@ for old_device in \$(ibdev2netdev -v | sort -n | cut -f2 -d' '); do
 	
 	if [ "\$link_layer" = "InfiniBand" ]; then
 		
-		\$rdma_rename \$old_device NAME_FIXED mlx_ib\${ib_index}
+		\$rdma_rename \$old_device NAME_FIXED mlx5_ib\${ib_index}
 		ib_index=\$((\$ib_index + 1))
 		
 	elif [ "\$link_layer" = "Ethernet" ]; then
 	
-		\$rdma_rename \$old_device NAME_FIXED mlx_an\${an_index}
+		\$rdma_rename \$old_device NAME_FIXED mlx5_an\${an_index}
 		an_index=\$((\$an_index + 1))
 		
 	else
@@ -67,3 +67,4 @@ WantedBy=multi-user.target
 EOF
 
 systemctl enable azure_persistent_rdma_naming.service
+systemctl start azure_persistent_rdma_naming.service

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install.sh
@@ -43,3 +43,6 @@ $COMMON_DIR/network-tuning.sh
 
 # copy test file
 $COMMON_DIR/copy_test_file.sh
+
+# install persistent rdma naming
+$COMMON_DIR/install_azure_persistent_rdma_naming.sh

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_utils.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_utils.sh
@@ -27,4 +27,7 @@ apt-get -y install numactl \
                    libnl-3-200 \
                    bison \
                    libnl-route-3-200 \
-                   gfortran
+                   gfortran \
+                   cmake \
+                   libnl-3-dev \
+                   libnl-route-3-dev

--- a/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install.sh
+++ b/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install.sh
@@ -43,3 +43,6 @@ $COMMON_DIR/network-tuning.sh
 
 # copy test file
 $COMMON_DIR/copy_test_file.sh
+
+# install persistent rdma naming
+$COMMON_DIR/install_azure_persistent_rdma_naming.sh

--- a/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_utils.sh
+++ b/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_utils.sh
@@ -27,4 +27,7 @@ apt-get -y install numactl \
                    libnl-3-200 \
                    bison \
                    libnl-route-3-200 \
-                   gfortran
+                   gfortran \
+                   cmake \
+                   libnl-3-dev \
+                   libnl-route-3-dev


### PR DESCRIPTION
Only manually tested on 7.7 and 7.8.  Do we have automation for all platforms?