### PR TITLE
Updated NVIDIA, MOFED and HPCX versions for Ubuntu 18.04

### DIFF
--- a/common/install_nccl.sh
+++ b/common/install_nccl.sh
@@ -11,8 +11,8 @@ git cherry-pick -x ef5f37461fdbf11104cf0ee13da80d80b84b4cbc
 make -j src.build
 make pkg.debian.build
 cd build/pkg/deb/
-sudo dpkg -i libnccl2_2.8.4-1+cuda11.0_amd64.deb
-sudo dpkg -i libnccl-dev_2.8.4-1+cuda11.0_amd64.deb
+sudo dpkg -i libnccl2_2.8.4-1+cuda11.2_amd64.deb
+sudo dpkg -i libnccl-dev_2.8.4-1+cuda11.2_amd64.deb
 
 # Install the nccl rdma sharp plugin
 cd /tmp
@@ -28,9 +28,8 @@ make install
 # Build the nccl tests
 source /etc/profile.d/modules.sh
 module load mpi/hpcx
-sudo mkdir -p /opt/microsoft
-cd /opt/microsoft
+cd /opt
 sudo git clone https://github.com/NVIDIA/nccl-tests.git
-cd /opt/microsoft/nccl-tests
+cd /opt/nccl-tests
 make MPI=1 MPI_HOME=${HPCX_MPI_DIR} CUDA_HOME=/usr/local/cuda
 module unload mpi/hpcx

--- a/common/install_nvidiagpudriver.sh
+++ b/common/install_nvidiagpudriver.sh
@@ -2,14 +2,14 @@
 set -ex
 
 # Nvidia driver
-NVIDIA_DRIVER_URL=https://download.nvidia.com/XFree86/Linux-x86_64/460.27.04/NVIDIA-Linux-x86_64-460.27.04.run
-$COMMON_DIR/download_and_verify.sh $NVIDIA_DRIVER_URL "a654eab5ce50650c0cd1fdcc78c655d0de573a2b925c20839252ffab2cbc1ccf"
+NVIDIA_DRIVER_URL=https://download.nvidia.com/XFree86/Linux-x86_64/460.32.03/NVIDIA-Linux-x86_64-460.32.03.run
+$COMMON_DIR/download_and_verify.sh $NVIDIA_DRIVER_URL "4f2122fc23655439f214717c4c35ab9b4f5ab8537cddfdf059a5682f1b726061"
 sudo bash NVIDIA-Linux-x86_64-460.27.04.run --silent
 
 # Install Cuda
-wget https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux.run
-chmod +x cuda_11.0.3_450.51.06_linux.run
-sudo ./cuda_11.0.3_450.51.06_linux.run --silent
+wget https://developer.download.nvidia.com/compute/cuda/11.2.2/local_installers/cuda_11.2.2_460.32.03_linux.run
+chmod +x cuda_11.2.2_460.32.03_linux.run
+sudo ./cuda_11.2.2_460.32.03_linux.run --silent
 echo 'export PATH=$PATH:/usr/local/cuda/bin' | sudo tee -a /etc/bash.bashrc
 echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64' | sudo tee -a /etc/bash.bashrc
 

--- a/common/install_nvidiagpudriver.sh
+++ b/common/install_nvidiagpudriver.sh
@@ -4,7 +4,7 @@ set -ex
 # Nvidia driver
 NVIDIA_DRIVER_URL=https://download.nvidia.com/XFree86/Linux-x86_64/460.32.03/NVIDIA-Linux-x86_64-460.32.03.run
 $COMMON_DIR/download_and_verify.sh $NVIDIA_DRIVER_URL "4f2122fc23655439f214717c4c35ab9b4f5ab8537cddfdf059a5682f1b726061"
-sudo bash NVIDIA-Linux-x86_64-460.27.04.run --silent
+sudo bash NVIDIA-Linux-x86_64-460.32.03.run --silent
 
 # Install Cuda
 wget https://developer.download.nvidia.com/compute/cuda/11.2.2/local_installers/cuda_11.2.2_460.32.03_linux.run

--- a/common/kernel-update.sh
+++ b/common/kernel-update.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -ex
-
-# Get the kernel
-apt install -y linux-image-unsigned-5.4.0-1040-azure/bionic-updates
-
-sudo reboot

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -19,9 +19,9 @@ CENTOS_MVAPICH2_PATH="/opt/mvapich2-2.3.5"
 CENTOS_MVAPICH2X_PATH="${MVAPICH2X_INSTALLATION_DIRECTORY}/gnu9.2.0/mofed5.1/azure-xpmem/mpirun"
 CENTOS_OPENMPI_PATH="/opt/openmpi-4.0.5"
 
-UBUNTU_MOFED_VERSION="MLNX_OFED_LINUX-5.2-1.0.4.0"
+UBUNTU_MOFED_VERSION="MLNX_OFED_LINUX-5.2-2.2.0.0"
 UBUNTU_MODULE_FILES_ROOT="/usr/share/modules/modulefiles"
-HPCX_OMB_PATH_UBUNTU_1804="/opt/hpcx-v2.7.4-gcc-${UBUNTU_MOFED_VERSION}-ubuntu18.04-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
+HPCX_OMB_PATH_UBUNTU_1804="/opt/hpcx-v2.8.1-gcc-${UBUNTU_MOFED_VERSION}-ubuntu18.04-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
 HPCX_OMB_PATH_UBUNTU_2004="/opt/hpcx-v2.7.4-gcc-${UBUNTU_MOFED_VERSION}-ubuntu20.04-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
 UBUNTU_IMPI2021_PATH="/opt/intel/oneapi/mpi/2021.1.1"
 UBUNTU_MVAPICH2_PATH="/opt/mvapich2-2.3.5"
@@ -332,8 +332,10 @@ then
     -x CUDA_DEVICE_ORDER=PCI_BUS_ID \
     -x NCCL_SOCKET_IFNAME=eth0 \
     -x NCCL_NET_GDR_LEVEL=5 \
-    -x NCCL_TOPO_FILE=/opt/microsoft/topo.xml \
-    /opt/microsoft/nccl-tests/build/all_reduce_perf -b1K -f2 -g1 -e 4G
+    -x NCCL_TOPO_FILE=/opt/microsoft/ndv4-topo.xml \
+    /opt/nccl-tests/build/all_reduce_perf -b1K -f2 -g1 -e 4G
+
+    check_exit_code "Single Node NCCL Test" "Failed"
 
     module unload mpi/hpcx
 fi

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install.sh
@@ -35,6 +35,9 @@ $COMMON_DIR/install_dcgm.sh
 # install diagnostic script
 "$COMMON_DIR/install_hpcdiag.sh"
 
+# install persistent rdma naming
+$COMMON_DIR/install_azure_persistent_rdma_naming.sh
+
 # optimizations
 ./hpc-tuning.sh
 
@@ -43,6 +46,3 @@ $COMMON_DIR/network-tuning.sh
 
 # copy test file
 $COMMON_DIR/copy_test_file.sh
-
-# install persistent rdma naming
-$COMMON_DIR/install_azure_persistent_rdma_naming.sh

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_mellanoxofed.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_mellanoxofed.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -ex
 
-MLNX_OFED_DOWNLOAD_URL=https://azhpcstor.blob.core.windows.net/azhpc-images-store/MLNX_OFED_LINUX-5.2-1.0.4.0-ubuntu18.04-x86_64.tgz
+MLNX_OFED_DOWNLOAD_URL=https://azhpcstor.blob.core.windows.net/azhpc-images-store/MLNX_OFED_LINUX-5.2-2.2.0.0-ubuntu18.04-x86_64.tgz
 TARBALL=$(basename ${MLNX_OFED_DOWNLOAD_URL})
 MOFED_FOLDER=$(basename ${MLNX_OFED_DOWNLOAD_URL} .tgz)
 
-$COMMON_DIR/download_and_verify.sh $MLNX_OFED_DOWNLOAD_URL "5fbc3aeaa777b2e7d86616e429f367cf5b21870c13fa4e4c775bed32d9330b8c"
+$COMMON_DIR/download_and_verify.sh $MLNX_OFED_DOWNLOAD_URL "7752410503a40e5fc9d31c77241413459242751d683265b8a6bde4471ebff5e7"
 tar zxvf ${TARBALL}
 
 ./${MOFED_FOLDER}/mlnxofedinstall --add-kernel-support --skip-unsupported-devices-check

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_mpis.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_mpis.sh
@@ -10,14 +10,14 @@ set GCC=/opt/${GCC_VERSION}/bin/gcc
 
 INSTALL_PREFIX=/opt
 
-# HPC-X v2.7.4
-HPCX_VERSION="v2.7.4"
+# HPC-X v2.8.1
+HPCX_VERSION="v2.8.1"
 
-HPCX_DOWNLOAD_URL=https://azhpcstor.blob.core.windows.net/azhpc-images-store/hpcx-v2.7.4-gcc-MLNX_OFED_LINUX-5.2-1.0.4.0-ubuntu18.04-x86_64.tbz
+HPCX_DOWNLOAD_URL=https://azhpcstor.blob.core.windows.net/azhpc-images-store/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-ubuntu18.04-x86_64.tbz
 TARBALL=$(basename ${HPCX_DOWNLOAD_URL})
 HPCX_FOLDER=$(basename ${HPCX_DOWNLOAD_URL} .tbz)
 
-$COMMON_DIR/download_and_verify.sh $HPCX_DOWNLOAD_URL "2b6ca6d05ed1d49d7cad8969fcd9ad2c3e1f99ed6ef955b184d29ad5852afa64"
+$COMMON_DIR/download_and_verify.sh $HPCX_DOWNLOAD_URL "d78da08a130c19e53c07c16dedfbeaecd400077d68c7d26770d079d0bcc17668"
 tar -xvf ${TARBALL}
 mv ${HPCX_FOLDER} ${INSTALL_PREFIX}
 HPCX_PATH=${INSTALL_PREFIX}/${HPCX_FOLDER}

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_nvidiagpudriver.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_nvidiagpudriver.sh
@@ -3,8 +3,8 @@
 $COMMON_DIR/install_nvidiagpudriver.sh
 
 # Install nvidia fabric manager (required for ND96asr_v4)
-NVIDIA_FABRIC_MNGR_URL=http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/nvidia-fabricmanager-450_450.80.02-1_amd64.deb
-$COMMON_DIR/download_and_verify.sh $NVIDIA_FABRIC_MNGR_URL "4f14f162ad40e0824695f7489e27b24cf762b733ffcb0f30f084a228659594bf"
-sudo apt install -y ./nvidia-fabricmanager-450_450.80.02-1_amd64.deb
+NVIDIA_FABRIC_MNGR_URL=http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/nvidia-fabricmanager-460_460.32.03-1_amd64.deb
+$COMMON_DIR/download_and_verify.sh $NVIDIA_FABRIC_MNGR_URL "157da63c4f7823bb5ae4428891978345a079830629e23579e0c3126f42a4411c"
+sudo apt install -y ./nvidia-fabricmanager-460_460.32.03-1_amd64.deb
 sudo systemctl enable nvidia-fabricmanager
 sudo systemctl start nvidia-fabricmanager


### PR DESCRIPTION
Updated NVIDIA Driver to 460.32.03, NVIDIA Fabric Manager to 460.32.03 and CUDA to 11.2.2_460.32.03; Updated Mellanox OFED to 5.2-2.2.0.0 and HPCX to v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0; Removed Kernel Update Script; Updated Tests; Changed NCCL Tests folder from /opt/microsoft to /opt.