### PR TITLE
Adding Scripts for CentOS 7.9

### DIFF
--- a/centos/centos-7.x/centos-7.9-hpc/README.md
+++ b/centos/centos-7.x/centos-7.9-hpc/README.md
@@ -1,0 +1,33 @@
+# CentOS 7.9 HPC Image
+
+The CentOS 7.9 HPC Image includes optimizations and recommended configurations to deliver optimal performance,
+consistency, and reliability. This image consists of the following HPC tools and libraries:
+
+- Mellanox OFED
+- Pre-configured IPoIB (IP-over-InfiniBand)
+- Popular InfiniBand based MPI Libraries
+  - HPC-X
+  - IntelMPI
+  - MVAPICH2
+  - OpenMPI
+- Communication Runtimes
+  - Libfabric
+  - OpenUCX
+- Optimized librares
+  - AMD Blis
+  - AMD FFTW
+  - AMD Flame
+  - Intel MKL
+- GPU Drivers
+  - Nvidia GPU Driver
+- NCCL
+  - NCCL RDMA Sharp Plugin
+  - NCCL Tests
+- NV Peer Memory (GPU Direct RDMA)
+- GRD Copy
+- Data Center GPU Manager
+- Azure HPC Diagnostics Tool
+
+Software packages are configured as environment modules. Users can select preferred MPI or software packages as follows:
+
+`module load <package-name>`

--- a/centos/centos-7.x/centos-7.9-hpc/hpc-tuning.sh
+++ b/centos/centos-7.x/centos-7.9-hpc/hpc-tuning.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+../common/hpc-tuning.sh
+

--- a/centos/centos-7.x/centos-7.9-hpc/install.sh
+++ b/centos/centos-7.x/centos-7.9-hpc/install.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -ex
+
+# set properties
+source ./set_properties.sh
+
+# install utils
+./install_utils.sh
+
+# install compilers
+./install_gcc.sh
+
+# install mellanox ofed
+./install_mellanoxofed.sh
+
+# install mpi libraries
+./install_mpis.sh
+
+# cleanup downloaded tarballs
+rm -rf *.tgz *.bz2 *.tbz *.tar.gz
+rm -rf -- */
+
+# install nvidia gpu driver
+./install_nvidiagpudriver.sh
+
+# install AMD tuned libraries
+./install_amd_libs.sh
+
+# install Intel libraries
+./install_intel_libs.sh
+
+# cleanup downloaded tarballs
+rm -rf *.tar.gz *_offline.sh *.rpm *.run
+
+# Install NCCL
+./install_nccl.sh
+
+# Install DCGM
+./install_dcgm.sh
+
+# optimizations
+./hpc-tuning.sh
+
+# Network Optimization
+$COMMON_DIR/network-tuning.sh
+
+# install persistent rdma naming
+$COMMON_DIR/install_azure_persistent_rdma_naming.sh
+
+# add udev rule
+$COMMON_DIR/../centos/common/add-udev-rules.sh
+
+# add interface rules
+$COMMON_DIR/../centos/common/network-config.sh
+
+# install diagnostic script
+"$COMMON_DIR/install_hpcdiag.sh"
+
+# copy test file
+$COMMON_DIR/copy_test_file.sh

--- a/centos/centos-7.x/centos-7.9-hpc/install_amd_libs.sh
+++ b/centos/centos-7.x/centos-7.9-hpc/install_amd_libs.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$COMMON_DIR/../centos/centos-7.x/common/install_amd_libs.sh

--- a/centos/centos-7.x/centos-7.9-hpc/install_dcgm.sh
+++ b/centos/centos-7.x/centos-7.9-hpc/install_dcgm.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -ex
+
+# Install DCGM
+DCGM_VERSION=2.1.7
+DCGM_URL=https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/datacenter-gpu-manager-${DCGM_VERSION}-1-x86_64.rpm
+$COMMON_DIR/download_and_verify.sh $DCGM_URL "5ba9f19805c372d7cc7cdc4e12178c0c36894c58bf8749001724db0a435ee7a2"
+sudo rpm -i datacenter-gpu-manager-${DCGM_VERSION}-1-x86_64.rpm
+sudo rm -f datacenter-gpu-manager-${DCGM_VERSION}-1-x86_64.rpm
+
+# Create service for dcgm to launch on bootup
+sudo bash -c "cat > /etc/systemd/system/dcgm.service" <<'EOF'
+[Unit]
+Description=DCGM service
+
+[Service]
+User=root
+PrivateTmp=false
+ExecStart=/usr/bin/nv-hostengine -n
+Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl enable dcgm
+sudo systemctl start dcgm

--- a/centos/centos-7.x/centos-7.9-hpc/install_gcc.sh
+++ b/centos/centos-7.x/centos-7.9-hpc/install_gcc.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+MODULE_FILES_DIRECTORY=/usr/share/Modules/modulefiles
+
+mkdir -p ${MODULE_FILES_DIRECTORY}
+
+$COMMON_DIR/install_gcc-9.2.sh ${MODULE_FILES_DIRECTORY}

--- a/centos/centos-7.x/centos-7.9-hpc/install_intel_libs.sh
+++ b/centos/centos-7.x/centos-7.9-hpc/install_intel_libs.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+$COMMON_DIR/install_intel_libs.sh
+

--- a/centos/centos-7.x/centos-7.9-hpc/install_mellanoxofed.sh
+++ b/centos/centos-7.x/centos-7.9-hpc/install_mellanoxofed.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -ex
+
+MLNX_OFED_DOWNLOAD_URL=https://azhpcstor.blob.core.windows.net/azhpc-images-store/MLNX_OFED_LINUX-5.2-1.0.4.0-rhel7.9-x86_64.tgz
+TARBALL=$(basename ${MLNX_OFED_DOWNLOAD_URL})
+MOFED_FOLDER=$(basename ${MLNX_OFED_DOWNLOAD_URL} .tgz)
+
+$COMMON_DIR/download_and_verify.sh $MLNX_OFED_DOWNLOAD_URL "eaefb19d8820153715436fb8df003ea9e1675c75165b515fcdbbed60d0551034"
+tar zxvf ${TARBALL}
+
+KERNEL=( $(rpm -q kernel | sed 's/kernel\-//g') )
+KERNEL=${KERNEL[-1]}
+# Uncomment the lines below if you are running this on a VM
+#RELEASE=( $(cat /etc/centos-release | awk '{print $4}') )
+#yum -y install http://olcentgbl.trafficmanager.net/centos/${RELEASE}/updates/x86_64/kernel-devel-${KERNEL}.rpm
+yum install -y kernel-devel-${KERNEL}
+./${MOFED_FOLDER}/mlnxofedinstall --kernel $KERNEL --kernel-sources /usr/src/kernels/${KERNEL} --add-kernel-support --skip-repo
+

--- a/centos/centos-7.x/centos-7.9-hpc/install_mpis.sh
+++ b/centos/centos-7.x/centos-7.9-hpc/install_mpis.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -ex
+
+# Load gcc
+GCC_VERSION=gcc-9.2.0
+export PATH=/opt/${GCC_VERSION}/bin:$PATH
+export LD_LIBRARY_PATH=/opt/${GCC_VERSION}/lib64:$LD_LIBRARY_PATH
+set CC=/opt/${GCC_VERSION}/bin/gcc
+set GCC=/opt/${GCC_VERSION}/bin/gcc
+
+
+INSTALL_PREFIX=/opt
+
+# HPC-X v2.7.4
+HPCX_VERSION="v2.7.4"
+HPCX_DOWNLOAD_URL=https://azhpcstor.blob.core.windows.net/azhpc-images-store/hpcx-v2.8.0-gcc-MLNX_OFED_LINUX-5.2-1.0.4.0-redhat7.9-x86_64.tbz
+TARBALL=$(basename ${HPCX_DOWNLOAD_URL})
+HPCX_FOLDER=$(basename ${HPCX_DOWNLOAD_URL} .tbz)
+
+$COMMON_DIR/download_and_verify.sh $HPCX_DOWNLOAD_URL "89331106ada279c20ff4052dd4aab8aa971471443960d1a99fad08c48f25baca"
+tar -xvf ${TARBALL}
+mv ${HPCX_FOLDER} ${INSTALL_PREFIX}
+HPCX_PATH=${INSTALL_PREFIX}/${HPCX_FOLDER}
+
+# Setup module files for MPIs
+mkdir -p /usr/share/Modules/modulefiles/mpi/
+
+# HPC-X
+cat << EOF >> /usr/share/Modules/modulefiles/mpi/hpcx-${HPCX_VERSION}
+#%Module 1.0
+#
+#  HPCx ${HPCX_VERSION}
+#
+conflict        mpi
+module load ${HPCX_PATH}/modulefiles/hpcx
+EOF
+
+# Create symlinks for modulefiles
+ln -s /usr/share/Modules/modulefiles/mpi/hpcx-${HPCX_VERSION} /usr/share/Modules/modulefiles/mpi/hpcx
+
+# Install platform independent MPIs
+../common/install_mpis.sh ${GCC_VERSION} ${HPCX_PATH}
+

--- a/centos/centos-7.x/centos-7.9-hpc/install_nccl.sh
+++ b/centos/centos-7.x/centos-7.9-hpc/install_nccl.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -ex
+
+# Install NCCL
+yum install -y rpm-build rpmdevtools
+pushd /tmp
+git clone https://github.com/NVIDIA/nccl.git
+pushd nccl
+git checkout v2.8.4-1
+git cherry-pick -x 99b8a0393ffa379f3b0b81f3d5c0baa6aad7abef
+git cherry-pick -x ef5f37461fdbf11104cf0ee13da80d80b84b4cbc
+make -j src.build
+make pkg.redhat.build
+rpm -i ./build/pkg/rpm/x86_64/libnccl-2.8.4-1+cuda11.2.x86_64.rpm
+rpm -i ./build/pkg/rpm/x86_64/libnccl-devel-2.8.4-1+cuda11.2.x86_64.rpm
+rpm -i ./build/pkg/rpm/x86_64/libnccl-static-2.8.4-1+cuda11.2.x86_64.rpm
+popd
+
+# Install the nccl rdma sharp plugin
+mkdir -p /usr/local/nccl-rdma-sharp-plugins
+git clone https://github.com/Mellanox/nccl-rdma-sharp-plugins.git
+pushd nccl-rdma-sharp-plugins
+./autogen.sh
+./configure --prefix=/usr/local/nccl-rdma-sharp-plugins --with-cuda=/usr/local/cuda
+make
+make install
+popd
+popd
+
+# Build the nccl tests
+source /etc/profile.d/modules.sh
+module load mpi/hpcx
+git clone https://github.com/NVIDIA/nccl-tests.git
+pushd nccl-tests
+make MPI=1 MPI_HOME=${HPCX_MPI_DIR} CUDA_HOME=/usr/local/cuda
+popd
+mv nccl-tests /opt/.
+module unload mpi/hpcx

--- a/centos/centos-7.x/centos-7.9-hpc/install_nvidiagpudriver.sh
+++ b/centos/centos-7.x/centos-7.9-hpc/install_nvidiagpudriver.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -ex
+
+# Install Cuda
+CUDA_URL=https://developer.download.nvidia.com/compute/cuda/11.2.2/local_installers/cuda_11.2.2_460.32.03_linux.run
+$COMMON_DIR/download_and_verify.sh $CUDA_URL "0a2e477224af7f6003b49edfd2bfee07667a8148fe3627cfd2765f6ad72fa19d"
+chmod +x cuda_11.2.2_460.32.03_linux.run
+sh cuda_11.2.2_460.32.03_linux.run --silent --driver --toolkit
+echo 'export PATH=$PATH:/usr/local/cuda/bin' | sudo tee -a /etc/bash.bashrc
+echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64' | sudo tee -a /etc/bash.bashrc
+
+# Nvidia driver
+NVIDIA_DRIVER_URL=https://download.nvidia.com/XFree86/Linux-x86_64/460.32.03/NVIDIA-Linux-x86_64-460.32.03.run
+$COMMON_DIR/download_and_verify.sh $NVIDIA_DRIVER_URL "4f2122fc23655439f214717c4c35ab9b4f5ab8537cddfdf059a5682f1b726061"
+bash NVIDIA-Linux-x86_64-460.32.03.run --silent
+
+# Install NV Peer Memory (GPU Direct RDMA)
+git clone https://github.com/Mellanox/nv_peer_memory.git
+pushd nv_peer_memory
+git checkout 1_1_0_Release
+./build_module.sh 
+rpmbuild --rebuild /tmp/nvidia_peer_memory-1.1-0.src.rpm
+rpm -ivh ~/rpmbuild/RPMS/x86_64/nvidia_peer_memory-1.1-0.x86_64.rpm
+sudo modprobe nv_peer_mem
+lsmod | grep nv
+popd
+
+sudo bash -c "cat > /etc/modules-load.d/nv_peer_mem.conf" <<'EOF'
+nv_peer_mem
+EOF
+
+sudo systemctl enable nv_peer_mem.service
+
+# Install GDRCopy
+yum install -y https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/s/subunit-0.0.21-2.el7.x86_64.rpm
+yum install -y https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/s/subunit-devel-0.0.21-2.el7.x86_64.rpm
+yum install -y https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/d/dkms-2.8.4-1.el7.noarch.rpm
+yum install -y rpm-build make check check-devel 
+git clone https://github.com/NVIDIA/gdrcopy.git
+pushd gdrcopy/packages/
+CUDA=/usr/local/cuda ./build-rpm-packages.sh
+rpm -Uvh gdrcopy-kmod-2.2-1dkms.noarch.rpm
+rpm -Uvh gdrcopy-2.2-1.x86_64.rpm
+rpm -Uvh gdrcopy-devel-2.2-1.noarch.rpm
+popd
+
+# Install Fabric Manager
+NVIDIA_FABRIC_MNGR_URL=http://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/nvidia-fabricmanager-460-460.32.03-1.x86_64.rpm
+$COMMON_DIR/download_and_verify.sh $NVIDIA_FABRIC_MNGR_URL "6801295b4d7d08682d7cc56b403139214f366dd65646824fed63be72294eb464"
+yum install -y ./nvidia-fabricmanager-460-460.32.03-1.x86_64.rpm
+systemctl enable nvidia-fabricmanager
+systemctl start nvidia-fabricmanager

--- a/centos/centos-7.x/centos-7.9-hpc/install_utils.sh
+++ b/centos/centos-7.x/centos-7.9-hpc/install_utils.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+../common/install_utils.sh
+

--- a/centos/centos-7.x/centos-7.9-hpc/set_properties.sh
+++ b/centos/centos-7.x/centos-7.9-hpc/set_properties.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export TOP_DIR=../../..
+export COMMON_DIR=../../../common
+export TEST_DIR=../../../tests

--- a/common/network-tuning.sh
+++ b/common/network-tuning.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -ex
 
 # Both configurations are specific to NDv4
 # Place the topology file in /opt/microsoft

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -11,6 +11,7 @@ CENTOS_MOFED_VERSION="MLNX_OFED_LINUX-5.2-1.0.4.0"
 HPCX_OMB_PATH_CENTOS_76="/opt/hpcx-v2.7.4-gcc-${CENTOS_MOFED_VERSION}-redhat7.6-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
 HPCX_OMB_PATH_CENTOS_77="/opt/hpcx-v2.7.4-gcc-${CENTOS_MOFED_VERSION}-redhat7.7-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
 HPCX_OMB_PATH_CENTOS_78="/opt/hpcx-v2.7.4-gcc-${CENTOS_MOFED_VERSION}-redhat7.8-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
+HPCX_OMB_PATH_CENTOS_79="/opt/hpcx-v2.8.0-gcc-${CENTOS_MOFED_VERSION}-redhat7.9-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
 HPCX_OMB_PATH_CENTOS_81="/opt/hpcx-v2.7.4-gcc-${CENTOS_MOFED_VERSION}-redhat8.1-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
 HPCX_OMB_PATH_CENTOS_83="/opt/hpcx-v2.8.0-gcc-${CENTOS_MOFED_VERSION}-redhat8.3-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
 CENTOS_MODULE_FILES_ROOT="/usr/share/Modules/modulefiles"
@@ -114,6 +115,24 @@ then
     MVAPICH2_PATH=${CENTOS_MVAPICH2_PATH}
     MVAPICH2X_PATH=${CENTOS_MVAPICH2X_PATH}
     OPENMPI_PATH=${CENTOS_OPENMPI_PATH}
+elif [[ $distro == "CentOS Linux 7.9.2009" ]]
+then
+    HPCX_OMB_PATH=${HPCX_OMB_PATH_CENTOS_79}
+    CHECK_HPCX=1
+    CHECK_IMPI_2021=1
+    CHECK_IMPI_2018=1
+    CHECK_OMPI=1
+    CHECK_MVAPICH2=1
+    CHECK_MVAPICH2X=0
+    MODULE_FILES_ROOT=${CENTOS_MODULE_FILES_ROOT}
+    MOFED_VERSION=${CENTOS_MOFED_VERSION}
+    IMPI2021_PATH=${CENTOS_IMPI2021_PATH}
+    MVAPICH2_PATH=${CENTOS_MVAPICH2_PATH}
+    MVAPICH2X_PATH=${CENTOS_MVAPICH2X_PATH}
+    OPENMPI_PATH=${CENTOS_OPENMPI_PATH}
+    CHECK_AOCL=1
+    CHECK_NV_PMEM=1
+    CHECK_NCCL=1
 elif [[ $distro == "CentOS Linux 8.1.1911" ]]
 then
     HPCX_OMB_PATH=${HPCX_OMB_PATH_CENTOS_81}
@@ -331,6 +350,7 @@ then
     -x UCX_TLS=tcp \
     -x CUDA_DEVICE_ORDER=PCI_BUS_ID \
     -x NCCL_SOCKET_IFNAME=eth0 \
+    -x NCCL_DEBUG=WARN \
     -x NCCL_NET_GDR_LEVEL=5 \
     -x NCCL_TOPO_FILE=/opt/microsoft/ndv4-topo.xml \
     /opt/nccl-tests/build/all_reduce_perf -b1K -f2 -g1 -e 4G


### PR DESCRIPTION
Adding the installation scripts for following libs for CentOS 7.9

- Mellanox OFED
- Pre-configured IPoIB (IP-over-InfiniBand)
- Popular InfiniBand based MPI Libraries
  - HPC-X
  - IntelMPI
  - MVAPICH2
  - OpenMPI
- Communication Runtimes
  - Libfabric
  - OpenUCX
- Optimized librares
  - AMD BLIS
  - AMD FFTW
  - AMD Flame
  - Intel MKL
- GPU Drivers
  - Nvidia GPU Driver
- NCCL
  - NCCL RDMA Sharp Plugin
  - NCCL Tests
- NV Peer Memory (GPU Direct RDMA)
- GRD Copy
- Data Center GPU Manager
- Azure HPC Diagnostics Tool

Testing :
These scripts have been tested on CentOS 7.9.2009 Gen2 by OpenLogic on Standard ND96asr_v4.

Notes :
1. Right now all the scripts lives in CentOS 7.9 directory. Therefore as part of code clean and merging we should pull the common code out to common directories.
2. The code is specific to NDv4 right now.