### PR TITLE
Disabling Cloud Init and Removing H/W Mac Address and DHCP Name

### DIFF
--- a/centos/centos-7.x/centos-7.9-hpc/disable_cloudinit.sh
+++ b/centos/centos-7.x/centos-7.9-hpc/disable_cloudinit.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -ex
+
+# Disable Cloud-Init
+cat << EOF >> /etc/cloud/cloud.cfg.d/99-custom-networking.cfg
+network: {config: disabled}
+EOF
+
+# Remove Hardware Mac Address and DHCP Name
+cp /etc/sysconfig/network-scripts/ifcfg-eth0 tempFile
+grep -v -E "HWADDR=|DHCP_HOSTNAME=" /etc/sysconfig/network-scripts/ifcfg-eth0 > tempFile
+mv tempFile /etc/sysconfig/network-scripts/ifcfg-eth0

--- a/centos/centos-7.x/centos-7.9-hpc/install.sh
+++ b/centos/centos-7.x/centos-7.9-hpc/install.sh
@@ -58,3 +58,6 @@ $COMMON_DIR/install_hpcdiag.sh
 
 # copy test file
 $COMMON_DIR/copy_test_file.sh
+
+# disable cloud-init
+./disable_cloudinit.sh


### PR DESCRIPTION
CentOS 7.9 disabling cloud-Init and removing hardware Mac address and DHCP name for eth0.