### PR TITLE
hold nvidia-fabricmanager version

### DIFF
--- a/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_nvidiagpudriver.sh
+++ b/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_nvidiagpudriver.sh
@@ -7,5 +7,6 @@ $UBUNTU_COMMON_DIR/install_nvidiagpudriver.sh
 NVIDIA_FABRIC_MNGR_URL=http://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/nvidia-fabricmanager-460_460.32.03-1_amd64.deb
 $COMMON_DIR/download_and_verify.sh $NVIDIA_FABRIC_MNGR_URL "157da63c4f7823bb5ae4428891978345a079830629e23579e0c3126f42a4411c"
 apt install -y ./nvidia-fabricmanager-460_460.32.03-1_amd64.deb
+apt-mark hold nvidia-fabricmanager-460
 systemctl enable nvidia-fabricmanager
 systemctl start nvidia-fabricmanager


### PR DESCRIPTION
The cuda drivers are installed via nvidia's ".run" script; whereas, the fabric manager is installed via the deb packages.  This means that if you run `apt-get upgrade`, `apt-get update`, the fabric manager and drivers will not be in sync, and you will get a cuda initialization error.  So, this change tries to fix this issue.