### PR TITLE
Driver updates, bug fixes for ubuntu 18.04, 20.04 images

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -21,14 +21,14 @@ CENTOS_MVAPICH2_PATH="/opt/mvapich2-2.3.6"
 CENTOS_MVAPICH2X_PATH="${MVAPICH2X_INSTALLATION_DIRECTORY}/gnu9.2.0/mofed5.1/azure-xpmem/mpirun"
 CENTOS_OPENMPI_PATH="/opt/openmpi-4.1.0"
 
-UBUNTU_MOFED_VERSION="MLNX_OFED_LINUX-5.2-2.2.3.0"
+UBUNTU_MOFED_VERSION="MLNX_OFED_LINUX-5.4-1.0.3.0"
 UBUNTU_MODULE_FILES_ROOT="/usr/share/modules/modulefiles"
-HPCX_OMB_PATH_UBUNTU_1804="/opt/hpcx-v2.8.3-gcc-${UBUNTU_MOFED_VERSION}-ubuntu18.04-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
-HPCX_OMB_PATH_UBUNTU_2004="/opt/hpcx-v2.8.3-gcc-${UBUNTU_MOFED_VERSION}-ubuntu20.04-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
+HPCX_OMB_PATH_UBUNTU_1804="/opt/hpcx-v2.9.0-gcc-${UBUNTU_MOFED_VERSION}-ubuntu18.04-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
+HPCX_OMB_PATH_UBUNTU_2004="/opt/hpcx-v2.9.0-gcc-${UBUNTU_MOFED_VERSION}-ubuntu20.04-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
 UBUNTU_IMPI2021_PATH="/opt/intel/oneapi/mpi/2021.2.0"
 UBUNTU_MVAPICH2_PATH="/opt/mvapich2-2.3.6"
 UBUNTU_MVAPICH2X_PATH="${MVAPICH2X_INSTALLATION_DIRECTORY}/gnu9.2.0/mofed5.0/advanced-xpmem/mpirun"
-UBUNTU_OPENMPI_PATH="/opt/openmpi-4.1.0"
+UBUNTU_OPENMPI_PATH="/opt/openmpi-4.1.1"
 
 CHECK_HPCX=0
 CHECK_IMPI_2021=0
@@ -179,6 +179,7 @@ then
     OPENMPI_PATH=${UBUNTU_OPENMPI_PATH}
     CHECK_AOCL=0
     CHECK_NV_PMEM=1
+    CHECK_GCC=0
     CHECK_NCCL=1
 elif [[ $distro == "Ubuntu 20.04" ]]
 then

--- a/ubuntu/common/disable_auto_upgrade.sh
+++ b/ubuntu/common/disable_auto_upgrade.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 
-su -c 'echo linux-image-5.4.0-1046-azure hold | dpkg --set-selections'
+KERNEL_VERSION=$(uname -r) su -c 'echo linux-image-$KERNEL_VERSION hold | dpkg --set-selections'
 sed -i 's/APT::Periodic::Unattended-Upgrade ".*/APT::Periodic::Unattended-Upgrade "0";/' /etc/apt/apt.conf.d/20auto-upgrades

--- a/ubuntu/common/hpc-tuning.sh
+++ b/ubuntu/common/hpc-tuning.sh
@@ -27,17 +27,9 @@ EOF
 echo "vm.zone_reclaim_mode = 1" >> /etc/sysctl.conf
 sysctl -p
 
-# Install WALinuxAgent
-apt-get install python3-setuptools
-git clone https://github.com/Azure/WALinuxAgent.git
-cd WALinuxAgent/
-git fetch origin pull/2239/head:ib_name
-git checkout ib_name
-python3 setup.py install --register-service
-
 # Configure WALinuxAgent
 sed -i -e 's/# OS.EnableRDMA=y/OS.EnableRDMA=y/g' /etc/waagent.conf
-echo "Extensions.GoalStatePeriod=300" | sudo tee -a /etc/waagent.conf
+echo "Extensions.GoalStatePeriod=120" | sudo tee -a /etc/waagent.conf
 echo "OS.EnableFirewallPeriod=300" | sudo tee -a /etc/waagent.conf
 echo "OS.RemovePersistentNetRulesPeriod=300" | sudo tee -a /etc/waagent.conf
 echo "OS.RootDeviceScsiTimeoutPeriod=300" | sudo tee -a /etc/waagent.conf

--- a/ubuntu/common/install_nccl.sh
+++ b/ubuntu/common/install_nccl.sh
@@ -11,7 +11,9 @@ make -j src.build
 make pkg.debian.build
 cd build/pkg/deb/
 dpkg -i libnccl2_2.9.9-1+cuda11.2_amd64.deb
+sudo apt-mark hold libnccl2
 dpkg -i libnccl-dev_2.9.9-1+cuda11.2_amd64.deb
+sudo apt mark hold libnccl-dev
 
 # Install the nccl rdma sharp plugin
 cd /tmp

--- a/ubuntu/common/install_nvidiagpudriver.sh
+++ b/ubuntu/common/install_nvidiagpudriver.sh
@@ -14,7 +14,9 @@ tar xzf /tmp/nvidia-peer-memory_1.1.orig.tar.gz
 cd nvidia-peer-memory-1.1/
 dpkg-buildpackage -us -uc 
 sudo dpkg -i ../nvidia-peer-memory_1.1-0_all.deb 
+sudo apt-mark hold nvidia-peer-memory
 sudo dpkg -i ../nvidia-peer-memory-dkms_1.1-0_all.deb 
+sudo apt-mark hold nvidia-peer-memory-dkms
 sudo modprobe nv_peer_mem
 lsmod | grep nv
 
@@ -25,9 +27,23 @@ EOF
 sudo systemctl enable nv_peer_mem.service
 
 # Install gdrcopy
-sudo apt install -y check libsubunit0 libsubunit-dev build-essential devscripts debhelper check libsubunit-dev fakeroot
+sudo apt install -y build-essential devscripts debhelper check libsubunit-dev fakeroot pkg-config dkms
 git clone https://github.com/NVIDIA/gdrcopy.git
 cd gdrcopy/packages/
 CUDA=/usr/local/cuda ./build-deb-packages.sh 
-sudo dpkg -i gdrdrv-dkms_2.2-1_amd64.deb 
-sudo dpkg -i gdrcopy_2.2-1_amd64.deb
+sudo dpkg -i gdrdrv-dkms_2.3-1_amd64.Ubuntu18_04.deb
+sudo apt-mark hold gdrdrv-dkms
+sudo dpkg -i libgdrapi_2.3-1_amd64.Ubuntu18_04.deb
+sudo apt-mark hold libgdrapi
+sudo dpkg -i gdrcopy-tests_2.3-1_amd64.Ubuntu18_04.deb
+sudo apt-mark hold gdrcopy-tests
+sudo dpkg -i gdrcopy_2.3-1_amd64.Ubuntu18_04.deb
+sudo apt-mark hold gdrcopy
+
+# Install nvidia fabric manager (required for ND96asr_v4)
+NVIDIA_FABRIC_MNGR_URL=http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/nvidia-fabricmanager-460_460.32.03-1_amd64.deb
+$COMMON_DIR/download_and_verify.sh $NVIDIA_FABRIC_MNGR_URL "157da63c4f7823bb5ae4428891978345a079830629e23579e0c3126f42a4411c"
+apt install -y ./nvidia-fabricmanager-460_460.32.03-1_amd64.deb
+sudo apt-mark hold nvidia-fabricmanager-460
+systemctl enable nvidia-fabricmanager
+systemctl start nvidia-fabricmanager

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/disable_auto_upgrade.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/disable_auto_upgrade.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -e
-
-su -c 'echo linux-image-5.4.0-1043-azure hold | dpkg --set-selections'
-sed -i 's/APT::Periodic::Unattended-Upgrade ".*/APT::Periodic::Unattended-Upgrade "0";/' /etc/apt/apt.conf.d/20auto-upgrades

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install.sh
@@ -7,9 +7,6 @@ source ./set_properties.sh
 # install utils
 ./install_utils.sh
 
-# install compilers
-./install_gcc.sh
-
 # install mellanox ofed
 ./install_mellanoxofed.sh
 
@@ -48,4 +45,4 @@ $COMMON_DIR/network-tuning.sh
 $COMMON_DIR/copy_test_file.sh
 
 # diable auto kernel updates
-./disable_auto_upgrade.sh
+$UBUNTU_COMMON_DIR/disable_auto_upgrade.sh

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_mellanoxofed.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_mellanoxofed.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 set -ex
 
-MLNX_OFED_DOWNLOAD_URL=https://azhpcstor.blob.core.windows.net/azhpc-images-store/MLNX_OFED_LINUX-5.2-2.2.3.0-ubuntu18.04-x86_64.tgz
+MLNX_OFED_DOWNLOAD_URL=https://azhpcstor.blob.core.windows.net/azhpc-images-store/MLNX_OFED_LINUX-5.4-1.0.3.0-ubuntu18.04-x86_64.tgz
 TARBALL=$(basename ${MLNX_OFED_DOWNLOAD_URL})
 MOFED_FOLDER=$(basename ${MLNX_OFED_DOWNLOAD_URL} .tgz)
 
-$COMMON_DIR/download_and_verify.sh $MLNX_OFED_DOWNLOAD_URL "e6a188a0089558e32f2493a52e7ed36d838fc03476a59391b5d537c321aa8a44"
+$COMMON_DIR/download_and_verify.sh $MLNX_OFED_DOWNLOAD_URL "6883710af0929e75d3254b2ffaea6fc1148e6997e28833eef751f4851cf42d30"
 tar zxvf ${TARBALL}
 
 ./${MOFED_FOLDER}/mlnxofedinstall --add-kernel-support --skip-unsupported-devices-check
 
+# Restarting openibd
+/etc/init.d/openibd restart

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_mpis.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_mpis.sh
@@ -3,21 +3,19 @@ set -e
 
 # Load gcc
 GCC_VERSION=gcc-9.2.0
-export PATH=/opt/${GCC_VERSION}/bin:$PATH
-export LD_LIBRARY_PATH=/opt/${GCC_VERSION}/lib64:$LD_LIBRARY_PATH
-set CC=/opt/${GCC_VERSION}/bin/gcc
-set GCC=/opt/${GCC_VERSION}/bin/gcc
+set CC=/usr/bin/gcc
+set GCC=/usr/bin/gcc
 
 INSTALL_PREFIX=/opt
 
-# HPC-X v2.8.3
-HPCX_VERSION="v2.8.3"
+# HPC-X v2.9.0
+HPCX_VERSION="v2.9.0"
 
-HPCX_DOWNLOAD_URL=https://azhpcstor.blob.core.windows.net/azhpc-images-store/hpcx-v2.8.3-gcc-MLNX_OFED_LINUX-5.2-2.2.3.0-ubuntu18.04-x86_64.tbz
+HPCX_DOWNLOAD_URL=https://azhpcstor.blob.core.windows.net/azhpc-images-store/hpcx-v2.9.0-gcc-MLNX_OFED_LINUX-5.4-1.0.3.0-ubuntu18.04-x86_64.tbz
 TARBALL=$(basename ${HPCX_DOWNLOAD_URL})
 HPCX_FOLDER=$(basename ${HPCX_DOWNLOAD_URL} .tbz)
 
-$COMMON_DIR/download_and_verify.sh $HPCX_DOWNLOAD_URL "61bfbee2ded031e605cf926e6ab0c0c8fe8b29524a3e23274412637e12e1c1c5"
+$COMMON_DIR/download_and_verify.sh $HPCX_DOWNLOAD_URL "5b395006a05c888794b0b6204198d3bab597a8333c982ea5409f4f18e65bcbef"
 tar -xvf ${TARBALL}
 mv ${HPCX_FOLDER} ${INSTALL_PREFIX}
 HPCX_PATH=${INSTALL_PREFIX}/${HPCX_FOLDER}
@@ -36,10 +34,10 @@ cd mvapich2-${MV2_VERSION}
 ./configure --prefix=${INSTALL_PREFIX}/mvapich2-${MV2_VERSION} --enable-g=none --enable-fast=yes && make -j$(nproc) && make install
 cd ..
 
-# OpenMPI 4.1.0
-OMPI_VERSION="4.1.0"
+# OpenMPI 4.1.1
+OMPI_VERSION="4.1.1"
 OMPI_DOWNLOAD_URL=https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-${OMPI_VERSION}.tar.gz
-$COMMON_DIR/download_and_verify.sh $OMPI_DOWNLOAD_URL "228467c3dd15339d9b26cf26a291af3ee7c770699c5e8a1b3ad786f9ae78140a"
+$COMMON_DIR/download_and_verify.sh $OMPI_DOWNLOAD_URL "d80b9219e80ea1f8bcfe5ad921bd9014285c4948c5965f4156a3831e60776444"
 tar -xvf openmpi-${OMPI_VERSION}.tar.gz
 cd openmpi-${OMPI_VERSION}
 ./configure --prefix=${INSTALL_PREFIX}/openmpi-${OMPI_VERSION} --with-ucx=${UCX_PATH} --with-hcoll=${HCOLL_PATH} --enable-mpirun-prefix-by-default --with-platform=contrib/platform/mellanox/optimized && make -j$(nproc) && make install
@@ -72,7 +70,6 @@ cat << EOF >> ${MODULE_FILES_DIRECTORY}/mvapich2-${MV2_VERSION}
 #  MVAPICH2 ${MV2_VERSION}
 #
 conflict        mpi
-module load ${GCC_VERSION}
 prepend-path    PATH            /opt/mvapich2-${MV2_VERSION}/bin
 prepend-path    LD_LIBRARY_PATH /opt/mvapich2-${MV2_VERSION}/lib
 prepend-path    MANPATH         /opt/mvapich2-${MV2_VERSION}/share/man
@@ -90,7 +87,6 @@ cat << EOF >> ${MODULE_FILES_DIRECTORY}/openmpi-${OMPI_VERSION}
 #  OpenMPI ${OMPI_VERSION}
 #
 conflict        mpi
-module load ${GCC_VERSION}
 prepend-path    PATH            /opt/openmpi-${OMPI_VERSION}/bin
 prepend-path    LD_LIBRARY_PATH /opt/openmpi-${OMPI_VERSION}/lib
 prepend-path    MANPATH         /opt/openmpi-${OMPI_VERSION}/share/man

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_nvidiagpudriver.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_nvidiagpudriver.sh
@@ -1,11 +1,3 @@
 #!/bin/bash
-set -ex
 
 $UBUNTU_COMMON_DIR/install_nvidiagpudriver.sh
-
-# Install nvidia fabric manager (required for ND96asr_v4)
-NVIDIA_FABRIC_MNGR_URL=http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/nvidia-fabricmanager-460_460.32.03-1_amd64.deb
-$COMMON_DIR/download_and_verify.sh $NVIDIA_FABRIC_MNGR_URL "157da63c4f7823bb5ae4428891978345a079830629e23579e0c3126f42a4411c"
-apt install -y ./nvidia-fabricmanager-460_460.32.03-1_amd64.deb
-systemctl enable nvidia-fabricmanager
-systemctl start nvidia-fabricmanager

--- a/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install.sh
+++ b/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install.sh
@@ -45,4 +45,4 @@ $COMMON_DIR/network-tuning.sh
 $COMMON_DIR/copy_test_file.sh
 
 # diable auto kernel updates
-./disable_auto_upgrade.sh
+$UBUNTU_COMMON_DIR/disable_auto_upgrade.sh

--- a/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_mellanoxofed.sh
+++ b/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_mellanoxofed.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 set -ex
 
-MLNX_OFED_DOWNLOAD_URL=https://azhpcstor.blob.core.windows.net/azhpc-images-store/MLNX_OFED_LINUX-5.2-2.2.3.0-ubuntu20.04-x86_64.tgz
+MLNX_OFED_DOWNLOAD_URL=https://azhpcstor.blob.core.windows.net/azhpc-images-store/MLNX_OFED_LINUX-5.4-1.0.3.0-ubuntu20.04-x86_64.tgz
 TARBALL=$(basename ${MLNX_OFED_DOWNLOAD_URL})
 MOFED_FOLDER=$(basename ${MLNX_OFED_DOWNLOAD_URL} .tgz)
 
-$COMMON_DIR/download_and_verify.sh $MLNX_OFED_DOWNLOAD_URL "72d38888489ba15784d5500fef9ff09c9ef338a5cdd44bfd916a63b06af28ef0"
+$COMMON_DIR/download_and_verify.sh $MLNX_OFED_DOWNLOAD_URL "3ab949727b2e55ebf08fa4a858431a9951455cc2f213ff6c6f8fd94c7070e3ac"
 tar zxvf ${TARBALL}
 
 ./${MOFED_FOLDER}/mlnxofedinstall --add-kernel-support --skip-unsupported-devices-check
 
+# Restarting openibd
+/etc/init.d/openibd restart

--- a/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_mpis.sh
+++ b/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_mpis.sh
@@ -8,14 +8,14 @@ set GCC=/usr/bin/gcc
 
 INSTALL_PREFIX=/opt
 
-# HPC-X v2.8.3 GCC 9.3.0
-HPCX_VERSION="v2.8.3"
+# HPC-X v2.9.0 GCC 9.3.0
+HPCX_VERSION="v2.9.0"
 
-HPCX_DOWNLOAD_URL=https://azhpcstor.blob.core.windows.net/azhpc-images-store/hpcx-v2.8.3-gcc-MLNX_OFED_LINUX-5.2-2.2.3.0-ubuntu20.04-x86_64.tbz
+HPCX_DOWNLOAD_URL=https://azhpcstor.blob.core.windows.net/azhpc-images-store/hpcx-v2.9.0-gcc-MLNX_OFED_LINUX-5.4-1.0.3.0-ubuntu20.04-x86_64.tbz
 TARBALL=$(basename ${HPCX_DOWNLOAD_URL})
 HPCX_FOLDER=$(basename ${HPCX_DOWNLOAD_URL} .tbz)
 
-$COMMON_DIR/download_and_verify.sh $HPCX_DOWNLOAD_URL "a3f0752218b00c9085fb518feb834d5870ce4ec212db03312217cc5ddc94ccf2"
+$COMMON_DIR/download_and_verify.sh $HPCX_DOWNLOAD_URL "e31db57df06f9be41bdb95e765ad438301021f388c14058db8e9261096b2cd4f"
 tar -xvf ${TARBALL}
 mv ${HPCX_FOLDER} ${INSTALL_PREFIX}
 HPCX_PATH=${INSTALL_PREFIX}/${HPCX_FOLDER}
@@ -34,10 +34,10 @@ cd mvapich2-${MV2_VERSION}
 ./configure --prefix=${INSTALL_PREFIX}/mvapich2-${MV2_VERSION} --enable-g=none --enable-fast=yes && make -j$(nproc) && make install
 cd ..
 
-# OpenMPI 4.1.0
-OMPI_VERSION="4.1.0"
+# OpenMPI 4.1.1
+OMPI_VERSION="4.1.1"
 OMPI_DOWNLOAD_URL=https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-${OMPI_VERSION}.tar.gz
-$COMMON_DIR/download_and_verify.sh $OMPI_DOWNLOAD_URL "228467c3dd15339d9b26cf26a291af3ee7c770699c5e8a1b3ad786f9ae78140a"
+$COMMON_DIR/download_and_verify.sh $OMPI_DOWNLOAD_URL "d80b9219e80ea1f8bcfe5ad921bd9014285c4948c5965f4156a3831e60776444"
 tar -xvf openmpi-${OMPI_VERSION}.tar.gz
 cd openmpi-${OMPI_VERSION}
 ./configure --prefix=${INSTALL_PREFIX}/openmpi-${OMPI_VERSION} --with-ucx=${UCX_PATH} --with-hcoll=${HCOLL_PATH} --enable-mpirun-prefix-by-default --with-platform=contrib/platform/mellanox/optimized && make -j$(nproc) && make install

--- a/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_nvidiagpudriver.sh
+++ b/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_nvidiagpudriver.sh
@@ -1,11 +1,3 @@
 #!/bin/bash
-set -ex
 
 $UBUNTU_COMMON_DIR/install_nvidiagpudriver.sh
-
-# Install nvidia fabric manager (required for ND96asr_v4)
-NVIDIA_FABRIC_MNGR_URL=http://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/nvidia-fabricmanager-460_460.32.03-1_amd64.deb
-$COMMON_DIR/download_and_verify.sh $NVIDIA_FABRIC_MNGR_URL "157da63c4f7823bb5ae4428891978345a079830629e23579e0c3126f42a4411c"
-apt install -y ./nvidia-fabricmanager-460_460.32.03-1_amd64.deb
-systemctl enable nvidia-fabricmanager
-systemctl start nvidia-fabricmanager


### PR DESCRIPTION
ubuntu driver updates; update MOFED 5.4-1.0.3.0; Update HPC-X 2.9.0 MOFED 5.4-1.0.3.0; fixed bugs; Set GoalStatePeriod to 120; Removed custom waagent; Holding auto updates for nvidia-fabricmanager and cuda drivers