### PR TITLE
Adding clear history for CentOS 7.9

### DIFF
--- a/centos/centos-7.x/centos-7.9-hpc/clear_history.sh
+++ b/centos/centos-7.x/centos-7.9-hpc/clear_history.sh
@@ -4,8 +4,7 @@ set -ex
 # Clear History
 sudo rm -rf /var/log/*
 sudo rm -f /etc/resolv.conf /var/lib/NetworkManager/* /etc/ssh/ssh_host_*
-sudo rm -rf /tmp/tmp*
-sudo rm -f /tmp/*.log* /tmp/ssh-* /tmp/yum*
+sudo rm -rf /tmp/ssh-* /tmp/yum* /tmp/tmp* /tmp/*.log* /tmp/*tenant*
 sudo rm -f /var/spool/plymouth/boot.log 
 sudo rm -f /var/lib/dhclient/* /var/lib/systemd/random-seed
 sudo rm -rf /var/cache/*
@@ -14,4 +13,12 @@ unset HISTFILE
 history -c
 sudo rm -rf /run/cloud-init /var/lib/cloud/instances/*
 yum clean all
+
+# Zero out unused space to minimize actual disk usage
+for part in $(awk '$3 == "xfs" {print $2}' /proc/mounts)
+do
+    dd if=/dev/zero of=${part}/EMPTY bs=1M || true;
+    rm -f ${part}/EMPTY
+done
+sync;
 

--- a/centos/centos-7.x/centos-7.9-hpc/clear_history.sh
+++ b/centos/centos-7.x/centos-7.9-hpc/clear_history.sh
@@ -4,7 +4,8 @@ set -ex
 # Clear History
 sudo rm -rf /var/log/*
 sudo rm -f /etc/resolv.conf /var/lib/NetworkManager/* /etc/ssh/ssh_host_*
-sudo rm -f /tmp/*.log* /tmp/ssh-* /tmp/yum*  /tmp/tmp*
+sudo rm -rf /tmp/tmp*
+sudo rm -f /tmp/*.log* /tmp/ssh-* /tmp/yum*
 sudo rm -f /var/spool/plymouth/boot.log 
 sudo rm -f /var/lib/dhclient/* /var/lib/systemd/random-seed
 sudo rm -rf /var/cache/*

--- a/centos/centos-7.x/centos-7.9-hpc/clear_history.sh
+++ b/centos/centos-7.x/centos-7.9-hpc/clear_history.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -ex
+
+# Clear History
+sudo rm -rf /var/log/*
+sudo rm -f /etc/resolv.conf /var/lib/NetworkManager/* /etc/ssh/ssh_host_*
+sudo rm -f /tmp/*.log* /tmp/ssh-* /tmp/yum*  /tmp/tmp*
+sudo rm -f /var/spool/plymouth/boot.log 
+sudo rm -f /var/lib/dhclient/* /var/lib/systemd/random-seed
+sudo rm -rf /var/cache/*
+unset HISTFILE
+#rm -f /root/.bash_history
+history -c
+sudo rm -rf /run/cloud-init /var/lib/cloud/instances/*
+yum clean all
+

--- a/centos/centos-7.x/centos-7.9-hpc/install.sh
+++ b/centos/centos-7.x/centos-7.9-hpc/install.sh
@@ -61,3 +61,7 @@ $COMMON_DIR/copy_test_file.sh
 
 # disable cloud-init
 ./disable_cloudinit.sh
+
+# clear history
+# Uncomment the line below if you are running this on a VM
+#./clear_history.sh


### PR DESCRIPTION
Adding clear history script for CentOS 7.9
- will need to uncomment line 67 in centos/centos-7.x/centos-7.9-hpc/install.sh when running on VM
- can also uncomment line 12 in centos/centos-7.x/centos-7.9-hpc/clear_history.sh to remove the root bash history

Testing
The scripts were tested on CentOS 7.9 Gen2 by Rogue Wave (OpenLogic) on Standard ND96asr_v4.