### PR TITLE
nvidia driver 495.29.05, CUDA 11.5.0, NCCL v2.11.4-1, DCGM 2.3.1 update for Ubuntu 18.04, 20.04 and CentOS 7.9

### DIFF
--- a/centos/centos-7.x/common/install_dcgm.sh
+++ b/centos/centos-7.x/common/install_dcgm.sh
@@ -2,10 +2,10 @@
 set -ex
 
 # Install DCGM
-DCGM_VERSION=2.1.7
+DCGM_VERSION=2.3.1
 $COMMON_DIR/write_component_version.sh "DCGM" ${DCGM_VERSION}
 DCGM_URL=https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/datacenter-gpu-manager-${DCGM_VERSION}-1-x86_64.rpm
-$COMMON_DIR/download_and_verify.sh $DCGM_URL "5ba9f19805c372d7cc7cdc4e12178c0c36894c58bf8749001724db0a435ee7a2"
+$COMMON_DIR/download_and_verify.sh $DCGM_URL "4bf0cccc4764f59b69e1df3b104ba8ecb77dc4bd98264b89d20aabd290808100"
 sudo rpm -i datacenter-gpu-manager-${DCGM_VERSION}-1-x86_64.rpm
 sudo rm -f datacenter-gpu-manager-${DCGM_VERSION}-1-x86_64.rpm
 

--- a/centos/centos-7.x/common/install_nvidiagpudriver.sh
+++ b/centos/centos-7.x/common/install_nvidiagpudriver.sh
@@ -6,7 +6,7 @@ $COMMON_DIR/install_nvidiagpudriver.sh
 # Install NV Peer Memory (GPU Direct RDMA)
 NV_PEER_MEMORY_VERSION="1.2-0"
 $COMMON_DIR/write_component_version.sh "NV_PEER_MEMORY" ${NV_PEER_MEMORY_VERSION}
-git clone https://github.com/gpudirect/nv_peer_memory.git --branch peermem_ex --single-branch
+git clone https://github.com/gpudirect/nv_peer_memory.git
 
 pushd nv_peer_memory
 yum install -y rpm-build
@@ -48,11 +48,11 @@ echo "exclude=gdrcopy-devel.noarch" | sudo tee -a /etc/yum.conf
 popd
 
 # Install Fabric Manager
-NVIDIA_FABRIC_MANAGER_VERSION="460-460.32.03-1"
+NVIDIA_FABRIC_MANAGER_VERSION="495.29.05-1"
 $COMMON_DIR/write_component_version.sh "NVIDIA_FABRIC_MANAGER" ${NVIDIA_FABRIC_MANAGER_VERSION}
-NVIDIA_FABRIC_MNGR_URL=http://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/nvidia-fabricmanager-${NVIDIA_FABRIC_MANAGER_VERSION}.x86_64.rpm
-$COMMON_DIR/download_and_verify.sh ${NVIDIA_FABRIC_MNGR_URL} "6801295b4d7d08682d7cc56b403139214f366dd65646824fed63be72294eb464"
-yum install -y ./nvidia-fabricmanager-${NVIDIA_FABRIC_MANAGER_VERSION}.x86_64.rpm
-echo "exclude=nvidia-fabricmanager-460" | sudo tee -a /etc/yum.conf
+NVIDIA_FABRIC_MNGR_URL=http://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/nvidia-fabric-manager-${NVIDIA_FABRIC_MANAGER_VERSION}.x86_64.rpm
+$COMMON_DIR/download_and_verify.sh ${NVIDIA_FABRIC_MNGR_URL} "d157e9e45cca7aab5eb73483444be32d747dc419fd23a3517c9a8e95db952272"
+yum install -y ./nvidia-fabric-manager-${NVIDIA_FABRIC_MANAGER_VERSION}.x86_64.rpm
+echo "exclude=nvidia-fabric-manager" | sudo tee -a /etc/yum.conf
 systemctl enable nvidia-fabricmanager
 systemctl start nvidia-fabricmanager

--- a/centos/common/install_nccl.sh
+++ b/centos/common/install_nccl.sh
@@ -3,7 +3,7 @@ set -ex
 
 # Install NCCL
 yum install -y rpm-build rpmdevtools
-NCCL_VERSION="2.9.9-1"
+NCCL_VERSION="2.11.4-1"
 $COMMON_DIR/write_component_version.sh "NCCL" ${NCCL_VERSION}
 TARBALL="v${NCCL_VERSION}.tar.gz"
 NCCL_DOWNLOAD_URL=https://github.com/NVIDIA/nccl/archive/refs/tags/${TARBALL}
@@ -14,11 +14,11 @@ tar -xvf ${TARBALL}
 pushd nccl-${NCCL_VERSION}
 make -j src.build
 make pkg.redhat.build
-rpm -i ./build/pkg/rpm/x86_64/libnccl-${NCCL_VERSION}+cuda11.2.x86_64.rpm
+rpm -i ./build/pkg/rpm/x86_64/libnccl-${NCCL_VERSION}+cuda11.5.x86_64.rpm
 echo "exclude=libnccl" | sudo tee -a /etc/yum.conf
-rpm -i ./build/pkg/rpm/x86_64/libnccl-devel-${NCCL_VERSION}+cuda11.2.x86_64.rpm
+rpm -i ./build/pkg/rpm/x86_64/libnccl-devel-${NCCL_VERSION}+cuda11.5.x86_64.rpm
 echo "exclude=libnccl-devel" | sudo tee -a /etc/yum.conf
-rpm -i ./build/pkg/rpm/x86_64/libnccl-static-${NCCL_VERSION}+cuda11.2.x86_64.rpm
+rpm -i ./build/pkg/rpm/x86_64/libnccl-static-${NCCL_VERSION}+cuda11.5.x86_64.rpm
 echo "exclude=libnccl-static" | sudo tee -a /etc/yum.conf
 popd
 

--- a/common/install_nvidiagpudriver.sh
+++ b/common/install_nvidiagpudriver.sh
@@ -2,11 +2,11 @@
 set -ex
 
 # Install Cuda
-NVIDIA_VERSION="460.32.03"
-CUDA_VERSION="11.2.2"
+NVIDIA_VERSION="495.29.05"
+CUDA_VERSION="11.5.0"
 $COMMON_DIR/write_component_version.sh "CUDA" ${CUDA_VERSION}
 CUDA_URL=https://developer.download.nvidia.com/compute/cuda/${CUDA_VERSION}/local_installers/cuda_${CUDA_VERSION}_${NVIDIA_VERSION}_linux.run
-$COMMON_DIR/download_and_verify.sh $CUDA_URL "0a2e477224af7f6003b49edfd2bfee07667a8148fe3627cfd2765f6ad72fa19d"
+$COMMON_DIR/download_and_verify.sh $CUDA_URL "ae0a1693d9497cf3d81e6948943e3794636900db71c98d58eefdacaf7f1a1e4c"
 chmod +x cuda_${CUDA_VERSION}_${NVIDIA_VERSION}_linux.run
 sh cuda_${CUDA_VERSION}_${NVIDIA_VERSION}_linux.run --silent
 echo 'export PATH=$PATH:/usr/local/cuda/bin' | sudo tee -a /etc/bash.bashrc
@@ -14,5 +14,6 @@ echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64' | sudo tee 
 
 # Nvidia driver
 NVIDIA_DRIVER_URL=https://download.nvidia.com/XFree86/Linux-x86_64/${NVIDIA_VERSION}/NVIDIA-Linux-x86_64-${NVIDIA_VERSION}.run
-$COMMON_DIR/download_and_verify.sh $NVIDIA_DRIVER_URL "4f2122fc23655439f214717c4c35ab9b4f5ab8537cddfdf059a5682f1b726061"
+$COMMON_DIR/download_and_verify.sh $NVIDIA_DRIVER_URL "f7254b97d400c692504796496f4e7d8f64e93b1e31c427860a4f219a186f125e"
 bash NVIDIA-Linux-x86_64-${NVIDIA_VERSION}.run --silent
+$COMMON_DIR/write_component_version.sh "NVIDIA" ${NVIDIA_VERSION}

--- a/ubuntu/common/install_dcgm.sh
+++ b/ubuntu/common/install_dcgm.sh
@@ -6,12 +6,12 @@ set -ex
 VERSION=$1
 
 # Install DCGM
-DCGM_VERSION=2.1.7
+DCGM_VERSION=2.3.1
 $COMMON_DIR/write_component_version.sh "DCGM" ${DCGM_VERSION}
 DCGM_GPUMNGR_URL=https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${VERSION}/x86_64/datacenter-gpu-manager_${DCGM_VERSION}_amd64.deb
-$COMMON_DIR/download_and_verify.sh $DCGM_GPUMNGR_URL "c55591b3f8ce66dc6215f1f40c6e7debdd557469ad911532642fd8622124e08f"
-dpkg -i datacenter-gpu-manager_*.deb && \
-rm -f datacenter-gpu-manager_*.deb
+$COMMON_DIR/download_and_verify.sh $DCGM_GPUMNGR_URL "0431dc987d3e67e6193b47c40ce71be443069c49adaa91ea0b904629b594a12c"
+dpkg -i datacenter-gpu-manager_${DCGM_VERSION}_amd64.deb && \
+rm -f datacenter-gpu-manager_${DCGM_VERSION}_amd64.deb
 
 # Create service for dcgm to launch on bootup
 bash -c "cat > /etc/systemd/system/dcgm.service" <<'EOF'

--- a/ubuntu/common/install_nccl.sh
+++ b/ubuntu/common/install_nccl.sh
@@ -3,7 +3,7 @@ set -ex
 
 # Install NCCL
 apt install -y build-essential devscripts debhelper fakeroot
-NCCL_VERSION="2.9.9-1"
+NCCL_VERSION="2.11.4-1"
 $COMMON_DIR/write_component_version.sh "NCCL" ${NCCL_VERSION}
 TARBALL="v${NCCL_VERSION}.tar.gz"
 NCCL_DOWNLOAD_URL=https://github.com/NVIDIA/nccl/archive/refs/tags/${TARBALL}
@@ -15,9 +15,9 @@ cd nccl-${NCCL_VERSION}/
 make -j src.build
 make pkg.debian.build
 cd build/pkg/deb/
-dpkg -i libnccl2_${NCCL_VERSION}+cuda11.2_amd64.deb
+dpkg -i libnccl2_${NCCL_VERSION}+cuda11.5_amd64.deb
 sudo apt-mark hold libnccl2
-dpkg -i libnccl-dev_${NCCL_VERSION}+cuda11.2_amd64.deb
+dpkg -i libnccl-dev_${NCCL_VERSION}+cuda11.5_amd64.deb
 sudo apt-mark hold libnccl-dev
 
 # Install the nccl rdma sharp plugin

--- a/ubuntu/common/install_nvidia_fabric_manager.sh
+++ b/ubuntu/common/install_nvidia_fabric_manager.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -ex
+
+# Parameter
+# Ubuntu Version
+VERSION=$1
+
+# Install nvidia fabric manager (required for ND96asr_v4)
+NVIDIA_FABRIC_MANAGER_VERSION="495_495.29.05-1"
+$COMMON_DIR/write_component_version.sh "NVIDIA_FABRIC_MANAGER" ${NVIDIA_FABRIC_MANAGER_VERSION}
+NVIDIA_FABRIC_MNGR_URL=http://developer.download.nvidia.com/compute/cuda/repos/ubuntu${VERSION}/x86_64/nvidia-fabricmanager-${NVIDIA_FABRIC_MANAGER_VERSION}_amd64.deb
+$COMMON_DIR/download_and_verify.sh $NVIDIA_FABRIC_MNGR_URL "eb756da0d8b7efe17af7972fa3764f64235e18c219799a532a91dbc457e650e3"
+apt install -y ./nvidia-fabricmanager-${NVIDIA_FABRIC_MANAGER_VERSION}_amd64.deb
+sudo apt-mark hold nvidia-fabricmanager-495
+systemctl enable nvidia-fabricmanager
+systemctl start nvidia-fabricmanager

--- a/ubuntu/common/install_nvidiagpudriver.sh
+++ b/ubuntu/common/install_nvidiagpudriver.sh
@@ -8,7 +8,7 @@ sudo apt install -y dkms libnuma-dev
 NV_PEER_MEMORY_VERSION="1.2-0"
 NV_PEER_MEMORY_VERSION_PREFIX=$(echo ${NV_PEER_MEMORY_VERSION} | awk -F- '{print $1}')
 $COMMON_DIR/write_component_version.sh "NV_PEER_MEMORY" ${NV_PEER_MEMORY_VERSION}
-git clone https://github.com/gpudirect/nv_peer_memory.git --branch peermem_ex --single-branch
+git clone https://github.com/gpudirect/nv_peer_memory.git
 
 cd nv_peer_memory
 ./build_module.sh 

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_dcgm.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_dcgm.sh
@@ -1,28 +1,2 @@
 #!/bin/bash
-set -ex
-
-# Install DCGM
-DCGM_VERSION=2.1.7
-$COMMON_DIR/write_component_version.sh "DCGM" ${DCGM_VERSION}
-DCGM_GPUMNGR_URL=https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/datacenter-gpu-manager_${DCGM_VERSION}_amd64.deb
-$COMMON_DIR/download_and_verify.sh $DCGM_GPUMNGR_URL "c55591b3f8ce66dc6215f1f40c6e7debdd557469ad911532642fd8622124e08f"
-sudo dpkg -i datacenter-gpu-manager_*.deb && \
-sudo rm -f datacenter-gpu-manager_*.deb
-
-# Create service for dcgm to launch on bootup
-sudo bash -c "cat > /etc/systemd/system/dcgm.service" <<'EOF'
-[Unit]
-Description=DCGM service
-
-[Service]
-User=root
-PrivateTmp=false
-ExecStart=/usr/bin/nv-hostengine -n
-Restart=on-abort
-
-[Install]
-WantedBy=multi-user.target
-EOF
-
-sudo systemctl enable dcgm
-sudo systemctl start dcgm
+$UBUNTU_COMMON_DIR/install_dcgm.sh 1804

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_nvidiagpudriver.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_nvidiagpudriver.sh
@@ -25,11 +25,4 @@ sudo apt-mark hold gdrcopy
 popd
 
 # Install nvidia fabric manager (required for ND96asr_v4)
-NVIDIA_FABRIC_MANAGER_VERSION="460_460.32.03-1"
-$COMMON_DIR/write_component_version.sh "NVIDIA_FABRIC_MANAGER" ${NVIDIA_FABRIC_MANAGER_VERSION}
-NVIDIA_FABRIC_MNGR_URL=http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/nvidia-fabricmanager-${NVIDIA_FABRIC_MANAGER_VERSION}_amd64.deb
-$COMMON_DIR/download_and_verify.sh $NVIDIA_FABRIC_MNGR_URL "157da63c4f7823bb5ae4428891978345a079830629e23579e0c3126f42a4411c"
-apt install -y ./nvidia-fabricmanager-${NVIDIA_FABRIC_MANAGER_VERSION}_amd64.deb
-sudo apt-mark hold nvidia-fabricmanager-460
-systemctl enable nvidia-fabricmanager
-systemctl start nvidia-fabricmanager
+$UBUNTU_COMMON_DIR/install_nvidia_fabric_manager.sh 1804

--- a/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_nvidiagpudriver.sh
+++ b/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_nvidiagpudriver.sh
@@ -25,11 +25,4 @@ sudo apt-mark hold gdrcopy
 popd
 
 # Install nvidia fabric manager (required for ND96asr_v4)
-NVIDIA_FABRIC_MANAGER_VERSION="460_460.32.03-1"
-$COMMON_DIR/write_component_version.sh "NVIDIA_FABRIC_MANAGER" ${NVIDIA_FABRIC_MANAGER_VERSION}
-NVIDIA_FABRIC_MNGR_URL=http://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/nvidia-fabricmanager-${NVIDIA_FABRIC_MANAGER_VERSION}_amd64.deb
-$COMMON_DIR/download_and_verify.sh $NVIDIA_FABRIC_MNGR_URL "157da63c4f7823bb5ae4428891978345a079830629e23579e0c3126f42a4411c"
-apt install -y ./nvidia-fabricmanager-${NVIDIA_FABRIC_MANAGER_VERSION}_amd64.deb
-sudo apt-mark hold nvidia-fabricmanager-460
-systemctl enable nvidia-fabricmanager
-systemctl start nvidia-fabricmanager
+$UBUNTU_COMMON_DIR/install_nvidia_fabric_manager.sh 2004


### PR DESCRIPTION
**Driver updates**

> NVIDIA - 495.29.05
> CUDA - 11.5.0
> NCCL - 2.11.4-1
> DCGM - 2.3.1