### PR TITLE
updated to use docker CE

### DIFF
--- a/ubuntu/common/install_docker.sh
+++ b/ubuntu/common/install_docker.sh
@@ -1,23 +1,8 @@
 #!/bin/bash
 set -ex
 
-# Install Moby Engine
-VERSION="3.0.1"
-$COMMON_DIR/write_component_version.sh "MOBY" $VERSION
-TARBALL="moby-$VERSION.tar.gz"
-MOBY_DOWNLOAD_URL=https://azhpcstor.blob.core.windows.net/azhpc-images-store/$TARBALL
-$COMMON_DIR/download_and_verify.sh ${MOBY_DOWNLOAD_URL} "7c91437fe67a6f51042896256843a50ffde83bd72b5d24fec3c0602781ceffa9"
-tar -xvzf ${TARBALL}
-tar -xvzf moby/amd64/artifacts.tgz -C moby/amd64/
-dpkg -i moby/amd64/bundles/debbuild/ubuntu-xenial/moby-engine_${VERSION}_amd64.deb
-
-# Install Moby CLI
-TARBALL="cli-$VERSION.tar.gz"
-CLI_DOWNLOAD_URL=https://azhpcstor.blob.core.windows.net/azhpc-images-store/$TARBALL
-$COMMON_DIR/download_and_verify.sh ${CLI_DOWNLOAD_URL} "6304942e8e99ddef30be63df33546e313b46128755e205af4e9fe12f50462ee6"
-tar -xvzf cli-$VERSION.tar.gz
-tar -xvzf cli/amd64/artifacts.tgz -C cli/amd64/
-dpkg -i cli/amd64/bundles/debbuild/ubuntu-xenial/moby-cli_${VERSION}_amd64.deb
+# Install Docker
+curl https://get.docker.com | sh && sudo systemctl --now enable docker
 
 # Install NVIDIA Docker
 # Reference: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html
@@ -46,8 +31,9 @@ chmod +x /bin/nvidia-docker
 wget https://raw.githubusercontent.com/NVIDIA/nvidia-docker/master/daemon.json
 cp daemon.json /etc/docker/
 
-# Working setup can be tested by running a base CUDA container
-# nvidia-docker run -e NVIDIA_VISIBLE_DEVICES=all nvidia/cuda:11.0-base nvidia-smi
+# Configure docker to not fill up the image disk and to not use the same address space as the IB network
+sudo systemctl stop docker
+sudo sh -c "echo '{  \"data-root\": \"/mnt/resource/docker\", \"bip\": \"152.26.0.1/16\", \"runtimes\": { \"nvidia\": { \"path\": \"/usr/bin/nvidia-container-runtime\", \"runtimeArgs\": [] } } }' > /etc/docker/daemon.json"
 
 # enable and restart the docker daemon to complete the installation
 systemctl enable docker


### PR DESCRIPTION
I removed Moby since it does not support all of the docker features and threw an error when I tried to run MLCommons Inferencing tests. I also added a docker configuration change so that it will not fill up the OS image disk and use a different address space than the IB 