### PR TITLE
Skip rdma renaming for Ubuntu LTS; Clear unwanted files; Update waagent v2.5.0.2 for Ubuntu

### DIFF
--- a/centos/centos-7.x/centos-7.9-hpc/clear_history.sh
+++ b/centos/centos-7.x/centos-7.9-hpc/clear_history.sh
@@ -9,13 +9,15 @@ rm -rf /var/log/*
 rm -f /etc/ssh/ssh_host_*
 rm -rf /tmp/ssh-* /tmp/yum* /tmp/tmp* /tmp/*.log* /tmp/*tenant*
 rm -rf /tmp/nvidia* /tmp/MLNX* /tmp/ofed.conf /tmp/dkms* /tmp/*mlnx*
-rm -f /var/lib/systemd/random-seed
-rm -rf /var/cache/*
-unset HISTFILE
-#rm -f /root/.bash_history
-history -c
+rm -rf /var/lib/systemd/random-seed /var/intel/ /var/cache/*
 rm -rf /run/cloud-init /var/lib/cloud/instances/*
+rm -rf /root/intel/
+
+# Empty machine information
+cat /dev/null > /etc/machine-id
+
 yum clean all
+du -sh /var/cache/yum/x86_64/7/*
 
 # Zero out unused space to minimize actual disk usage
 for part in $(awk '$3 == "xfs" {print $2}' /proc/mounts)
@@ -25,3 +27,6 @@ do
 done
 sync;
 
+unset HISTFILE
+#rm -f /root/.bash_history
+history -c

--- a/centos/centos-7.x/common/install_docker.sh
+++ b/centos/centos-7.x/common/install_docker.sh
@@ -42,3 +42,11 @@ systemctl restart docker
 # Write the docker version to components file
 docker_version=$(nvidia-docker --version | awk -F' ' '{print $3}')
 $COMMON_DIR/write_component_version.sh "NVIDIA-DOCKER" ${docker_version::-1}
+
+# Clean repos
+rm -rf /etc/yum.repos.d/nvidia-*
+rm -rf /etc/yum.repos.d/microsoft-prod.repo
+
+rm -rf /var/cache/yum/x86_64/7/packages-microsoft-com-prod/
+rm -rf /var/cache/yum/x86_64/7/nvidia-*
+rm -rf /var/cache/yum/x86_64/7/libnvidia-container/

--- a/centos/common/install_nccl.sh
+++ b/centos/common/install_nccl.sh
@@ -42,3 +42,7 @@ make MPI=1 MPI_HOME=${HPCX_MPI_DIR} CUDA_HOME=/usr/local/cuda
 popd
 mv nccl-tests /opt/.
 module unload mpi/hpcx
+
+# Remove installation files
+rm -rf /tmp/${TARBALL}
+rm -rf /tmp/nccl-${NCCL_VERSION}

--- a/ubuntu/common/clear_history.sh
+++ b/ubuntu/common/clear_history.sh
@@ -4,10 +4,13 @@ set -ex
 # Remove logs, cache, temporary installation dir and other host info
 rm -rf /var/log/*
 rm -f /etc/ssh/ssh_host_*
-rm -rf /tmp/nccl* /tmp/*.gz /tmp/nvidia* /tmp/MLNX* /tmp/*.log* /tmp/ofed.conf
-rm -f /var/lib/systemd/random-seed
-rm -rf /var/cache/*
-rm -rf /run/cloud-init /var/lib/cloud/instances/*
+rm -rf /tmp/*.gz /tmp/nvidia* /tmp/MLNX* /tmp/*.log* /tmp/ofed.conf /tmp/tmp*
+rm -rf /var/lib/systemd/random-seed /var/intel/ /var/cache/* /var/lib/cloud/instances/*
+rm -rf /run/cloud-init
+rm -rf /root/intel/
+
+# Empty machine information
+cat /dev/null > /etc/machine-id
 
 # Clear bash history
 cat /dev/null > ~/.bash_history && history -c

--- a/ubuntu/common/hpc-tuning.sh
+++ b/ubuntu/common/hpc-tuning.sh
@@ -29,12 +29,12 @@ sysctl -p
 
 # Install WALinuxAgent
 apt-get install python3-setuptools
-WAAGENT_VERSION=v2.5.0.1
+WAAGENT_VERSION=2.5.0.2
 $COMMON_DIR/write_component_version.sh "WAAGENT" ${WAAGENT_VERSION}
-DOWNLOAD_URL=https://github.com/Azure/WALinuxAgent/archive/refs/tags/pre-${WAAGENT_VERSION}.tar.gz
+DOWNLOAD_URL=https://github.com/Azure/WALinuxAgent/archive/refs/tags/v${WAAGENT_VERSION}.tar.gz
 wget ${DOWNLOAD_URL}
 tar -xvf $(basename ${DOWNLOAD_URL})
-pushd WALinuxAgent-pre-${WAAGENT_VERSION}/
+pushd WALinuxAgent-${WAAGENT_VERSION}/
 python3 setup.py install --register-service
 popd
 
@@ -47,4 +47,5 @@ echo "OS.RemovePersistentNetRulesPeriod=300" | sudo tee -a /etc/waagent.conf
 echo "OS.RootDeviceScsiTimeoutPeriod=300" | sudo tee -a /etc/waagent.conf
 echo "OS.MonitorDhcpClientRestartPeriod=60" | sudo tee -a /etc/waagent.conf
 echo "Provisioning.MonitorHostNamePeriod=60" | sudo tee -a /etc/waagent.conf
+systemctl daemon-reload
 systemctl restart walinuxagent

--- a/ubuntu/common/install_docker.sh
+++ b/ubuntu/common/install_docker.sh
@@ -41,3 +41,8 @@ systemctl restart docker
 # Write the docker version to components file
 docker_version=$(nvidia-docker --version | awk -F' ' '{print $3}')
 $COMMON_DIR/write_component_version.sh "NVIDIA-DOCKER" ${docker_version::-1}
+
+# Remove unwanted repos
+rm -f /etc/apt/sources.list.d/nvidia*
+rm -f /etc/apt/sources.list.d/microsoft-prod.list
+rm -f /etc/apt/trusted.gpg.d/microsoft.gpg

--- a/ubuntu/common/install_nccl.sh
+++ b/ubuntu/common/install_nccl.sh
@@ -47,3 +47,7 @@ CUDA_DEVICE_ORDER=PCI_BUS_ID
 NCCL_TOPO_FILE=/opt/microsoft/ndv4-topo.xml
 NCCL_SOCKET_IFNAME=eth0
 EOF
+
+# Remove installation files
+rm -rf /tmp/${TARBALL}
+rm -rf /tmp/nccl-${NCCL_VERSION}

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-LTS-hpc/install.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-LTS-hpc/install.sh
@@ -32,9 +32,6 @@ rm -Rf -- */
 # install diagnostic script
 $COMMON_DIR/install_hpcdiag.sh
 
-# install persistent rdma naming
-$COMMON_DIR/install_azure_persistent_rdma_naming.sh
-
 # optimizations
 $UBUNTU_COMMON_DIR/hpc-tuning.sh
 


### PR DESCRIPTION
### Change List
- Skip NIC renaming for Ubuntu 18.04 Images with MOFED-LTS
- Clear debris in /tmp/ and /root/
- Clear machine ID before deprovisioning
- Remove unwanted repositories and installation files
- Updated WALinuxAgent to 2.5.0.2 for Ubuntu Images