### PR TITLE
Rocm

### DIFF
--- a/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install.sh
+++ b/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install.sh
@@ -44,6 +44,10 @@ $UBUNTU_COMMON_DIR/disable_auto_upgrade.sh
 ./install_rocm.sh
 ./install_rccl.sh
 
+ibps="\nACTION==\"add\", SUBSYSTEM==\"net\", DRIVERS==\"?*\", ATTR{type}"
+ibps+="==\"32\", KERNEL==\"ib*\", NAME=\"ib0\""
+echo -e $ibps | sudo tee -a /etc/udev/rules.d/70-persistent-ipoib.rules
+
 # clear history
 # Uncomment the line below if you are running this on a VM
 # $UBUNTU_COMMON_DIR/clear_history.sh

--- a/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_rccl.sh
+++ b/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_rccl.sh
@@ -3,6 +3,8 @@ set -ex
 
 sudo apt-get install -y rocblas rccl-dev rccl-rdma-sharp-plugins
 
+sudo sysctl kernel.numa_balancing=0
+
 git clone https://github.com/ROCmSoftwarePlatform/rccl-tests
 cd rccl-tests
 

--- a/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_rccl.sh
+++ b/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_rccl.sh
@@ -14,8 +14,12 @@ RCCLLIB="/opt/rocm/rccl/lib/librccl.so"
 RCCLDIR="/opt/rocm/rccl"
 HIPDIR="/opt/rocm/hip"
 
-make MPI=1 MPI_HOME=$HPCX HIP_HOME=$HIPDIR NCCL_HOME=$RCCLDIR \
-	CUSTOM_RCCL_LIB=$RCCLLIB
+
+echo "gfx90a" > target.lst
+
+ROCM_TARGET_LST=$(pwd)/target.lst make MPI=1 MPI_HOME=$HPCX HIP_HOME=$HIPDIR \
+        NCCL_HOME=$RCCLDIR CUSTOM_RCCL_LIB=$RCCLLIB
+
 cd ..
 
 DEST_TEST_DIR=/opt/rccl-tests

--- a/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_rocm.sh
+++ b/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_rocm.sh
@@ -2,11 +2,20 @@
 set -ex
 
 #
+#install extra modules to make sure modprobe works
+sudo apt install -y linux-generic
+ver=$(uname -r)
+pack="linux-modules-extra-$ver"
+sudo apt install -y $pack
+
 wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
-amddeb="https://repo.radeon.com/amdgpu-install/22.10.1/ubuntu/focal/"
-amddeb+="amdgpu-install_22.10.1.50101-1_all.deb"
+
+
+sudo apt-get update
+amddeb="https://repo.radeon.com/amdgpu-install/22.10.3/ubuntu/focal/"
+amddeb+="amdgpu-install_22.10.3.50103-1_all.deb"
 wget $amddeb
-sudo apt-get install -y ./amdgpu-install_22.10.1.50101-1_all.deb
+sudo apt-get install -y ./amdgpu-install_22.10.3.50103-1_all.deb
 sudo amdgpu-install -y --usecase=rocm
 
 
@@ -19,19 +28,32 @@ echo 'ADD_EXTRA_GROUPS=1' | sudo tee -a /etc/adduser.conf
 echo 'EXTRA_GROUPS=video' | sudo tee -a /etc/adduser.conf
 echo 'EXTRA_GROUPS=render' | sudo tee -a /etc/adduser.conf
 
-echo -e '#!/usr/bin/bash\n\nsudo modprobe amdgpu' | sudo tee rocmstartup.sh
+#update grub settings
+pre=$(cat /etc/default/grub.d/50-cloudimg-settings.cfg | grep GRUB_CMDLINE_LINUX= | cut -d"\"" -f2)
+string="GRUB_CMDLINE_LINUX=\"$pre amd_iommu=on iommu=pt\""
+line=$(cat /etc/default/grub.d/50-cloudimg-settings.cfg | grep GRUB_CMDLINE_LINUX=)
+cat /etc/default/grub.d/50-cloudimg-settings.cfg | sed -e "s/$line/$string/" > temp_file.txt
+sudo mv temp_file.txt /etc/default/grub.d/50-cloudimg-settings.cfg
 
-sudo mv rocmstartup.sh /usr/local/bin/rocmstartup.sh
-sudo chown :render /usr/local/bin/rocmstartup.sh
-sudo chmod g+x /usr/local/bin/rocmstartup.sh
+string="GRUB_CMDLINE_LINUX_DEFAULT=\"panic=0 nowatchdog amd_iommu=on iommu=pt\""
+line=$(cat /etc/default/grub.d/50-cloudimg-settings.cfg | grep GRUB_CMDLINE_LINUX_DEFAULT=)
+cat /etc/default/grub.d/50-cloudimg-settings.cfg | sed -e "s/$line/$string/" > temp_file.txt
+sudo mv temp_file.txt /etc/default/grub.d/50-cloudimg-settings.cfg
+sudo update-grub
 
-echo -e '[Unit]\n\nDescription=Runs /usr/local/bin/rocmstartup.sh\n\n' \
-        | sudo tee rocmstartup.service
-echo -e '[Service]\n\nExecStart=/usr/local/bin/rocmstartup.sh\n\n' \
-        | sudo tee -a rocmstartup.service
-echo -e '[Install]\n\nWantedBy=multi-user.target' \
-        | sudo tee -a rocmstartup.service
-
-sudo mv rocmstartup.service /etc/systemd/system/rocmstartup.service
-sudo systemctl start rocmstartup
-sudo systemctl enable rocmstartup
+#echo -e '#!/usr/bin/bash\n\nsleep 120s\nsudo modprobe amdgpu' | sudo tee rocmstartup.sh
+#
+#sudo mv rocmstartup.sh /usr/local/bin/rocmstartup.sh
+#sudo chown :render /usr/local/bin/rocmstartup.sh
+#sudo chmod g+x /usr/local/bin/rocmstartup.sh
+#
+#echo -e '[Unit]\n\nDescription=Runs /usr/local/bin/rocmstartup.sh\n\n' \
+#        | sudo tee rocmstartup.service
+#echo -e '[Service]\n\nExecStart=/usr/local/bin/rocmstartup.sh\n\n' \
+#        | sudo tee -a rocmstartup.service
+#echo -e '[Install]\n\nWantedBy=multi-user.target' \
+#        | sudo tee -a rocmstartup.service
+#
+#sudo mv rocmstartup.service /etc/systemd/system/rocmstartup.service
+#sudo systemctl start rocmstartup
+#sudo systemctl enable rocmstartup

--- a/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_rocm.sh
+++ b/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_rocm.sh
@@ -11,11 +11,11 @@ sudo apt install -y $pack
 wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
 
 
-sudo apt-get update
-amddeb="https://repo.radeon.com/amdgpu-install/22.10.3/ubuntu/focal/"
-amddeb+="amdgpu-install_22.10.3.50103-1_all.deb"
+wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
+amddeb="https://repo.radeon.com/amdgpu-install/22.10.1/ubuntu/focal/"
+amddeb+="amdgpu-install_22.10.1.50101-1_all.deb"
 wget $amddeb
-sudo apt-get install -y ./amdgpu-install_22.10.3.50103-1_all.deb
+sudo apt-get install -y ./amdgpu-install_22.10.1.50101-1_all.deb
 sudo amdgpu-install -y --usecase=rocm
 
 
@@ -41,19 +41,3 @@ cat /etc/default/grub.d/50-cloudimg-settings.cfg | sed -e "s/$line/$string/" > t
 sudo mv temp_file.txt /etc/default/grub.d/50-cloudimg-settings.cfg
 sudo update-grub
 
-#echo -e '#!/usr/bin/bash\n\nsleep 120s\nsudo modprobe amdgpu' | sudo tee rocmstartup.sh
-#
-#sudo mv rocmstartup.sh /usr/local/bin/rocmstartup.sh
-#sudo chown :render /usr/local/bin/rocmstartup.sh
-#sudo chmod g+x /usr/local/bin/rocmstartup.sh
-#
-#echo -e '[Unit]\n\nDescription=Runs /usr/local/bin/rocmstartup.sh\n\n' \
-#        | sudo tee rocmstartup.service
-#echo -e '[Service]\n\nExecStart=/usr/local/bin/rocmstartup.sh\n\n' \
-#        | sudo tee -a rocmstartup.service
-#echo -e '[Install]\n\nWantedBy=multi-user.target' \
-#        | sudo tee -a rocmstartup.service
-#
-#sudo mv rocmstartup.service /etc/systemd/system/rocmstartup.service
-#sudo systemctl start rocmstartup
-#sudo systemctl enable rocmstartup


### PR DESCRIPTION
These changes block amdgpu from being loaded at startup (so users can run modprobe amdgpu themselves later). It also fixes a problem with how the rccl tests were compiled, and changes some ib naming things to be consistent with other hpc images. 