### PR TITLE
rolling back ib naming fix

### DIFF
--- a/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install.sh
+++ b/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install.sh
@@ -44,10 +44,6 @@ $UBUNTU_COMMON_DIR/disable_auto_upgrade.sh
 ./install_rocm.sh
 ./install_rccl.sh
 
-ibps="\nACTION==\"add\", SUBSYSTEM==\"net\", DRIVERS==\"?*\", ATTR{type}"
-ibps+="==\"32\", KERNEL==\"ib*\", NAME=\"ib0\""
-echo -e $ibps | sudo tee -a /etc/udev/rules.d/70-persistent-ipoib.rules
-
 # clear history
 # Uncomment the line below if you are running this on a VM
 # $UBUNTU_COMMON_DIR/clear_history.sh


### PR DESCRIPTION
Rolling back the naming change because it causes problems in some instances. 