### PR TITLE
Add Safeguards to Az Pipeline 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,17 +6,20 @@ pr:
 pool:
   vmImage: ubuntu-latest
 
-steps:
-- bash: |
-    echo $(System.PullRequest.PullRequestNumber)
-  displayName: Print PR Num
+jobs:
+- job: queue_azdo
+  timeoutInMinutes: 360
+  steps:
+  - bash: |
+      echo $(System.PullRequest.PullRequestNumber)
+    displayName: Print PR Num
 
-- task: Bash@3
-  inputs:
-    targetType: 'filePath'
-    filePath: './azure-pipelines/queue_ado.sh'
-    failOnStderr: true
-  env:
-    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    PR_NUM: $(System.PullRequest.PullRequestNumber)
-  displayName: Queue Validation Build and Monitor Status
+  - task: Bash@3
+    inputs:
+      targetType: 'filePath'
+      filePath: './azure-pipelines/queue_ado.sh'
+      failOnStderr: true
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      PR_NUM: $(System.PullRequest.PullRequestNumber)
+    displayName: Queue Validation Build and Monitor Status

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,8 +3,8 @@ trigger: none
 pr:
 - master
 
-pool:
-  vmImage: ubuntu-latest
+pool: 
+  name: 1ES-hosted-pool-scrub1
 
 jobs:
 - job: queue_azdo

--- a/azure-pipelines/queue_ado.sh
+++ b/azure-pipelines/queue_ado.sh
@@ -13,15 +13,22 @@ get_builds_res () {
 
 
 # Queue a build
-post_build_res=$(curl -s -X POST "https://dev.azure.com/hpc-platform-team/hpc-image-val/_apis/build/builds?api-version=6.0" \
+res_code=$(curl -s -w "%{response_code}\n" -o post.json -X POST "https://dev.azure.com/hpc-platform-team/hpc-image-val/_apis/build/builds?api-version=6.0" \
 -H "Authorization: Bearer $SYSTEM_ACCESSTOKEN" -H "Content-Type: application/json" \
 --data-raw "{\"definition\": {\"id\": 3}, \"sourceBranch\": \"github_pr\", \"parameters\": \"{\\\"PR_NUM\\\": \\\"$PR_NUM\\\"}\"}")
+
+if [ $res_code -ne 200 ]
+then
+    echo "Error! Could not queue build. Response code: $res_code"
+    exit 1
+fi
 
 echo "Queued build!"
 
 # Get URL for queued AzDo build
+post_build_res=$(cat ./post.json)
 build_url=$(echo $post_build_res | jq -r "._links.self.href")
-echo "Build url: $build_url"
+echo "Build url: $(echo $post_build_res | jq -r "._links.web.href")"
 
 # Wait until build finishes
 build_status=$(get_builds_res | jq -r ".status")


### PR DESCRIPTION
Added some safeguards to mitigate common pipeline run failures. 
- Abort pipeline run if queue request fails (POST returns anything but response code 200).
- Increase job timeout to 6hrs
- Switch to 1ES hosted pool