### PR TITLE
Updated nvidia gpu driver to 510.85.02

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -430,7 +430,6 @@ then
         --map-by ppr:8:node \
         -x LD_LIBRARY_PATH=/usr/local/nccl-rdma-sharp-plugins/lib:$LD_LIBRARY_PATH \
         -mca coll_hcoll_enable 0 \
-        -x UCX_IB_PCI_RELAXED_ORDERING=on \
         -x UCX_TLS=tcp \
         -x CUDA_DEVICE_ORDER=PCI_BUS_ID \
         -x NCCL_SOCKET_IFNAME=eth0 \

--- a/ubuntu/common/install_nccl.sh
+++ b/ubuntu/common/install_nccl.sh
@@ -3,7 +3,7 @@ set -ex
 
 # Install NCCL
 apt install -y build-essential devscripts debhelper fakeroot
-NCCL_VERSION="2.12.12-1"
+NCCL_VERSION="2.14.3-1"
 TARBALL="v${NCCL_VERSION}.tar.gz"
 NCCL_DOWNLOAD_URL=https://github.com/NVIDIA/nccl/archive/refs/tags/${TARBALL}
 pushd /tmp

--- a/ubuntu/common/install_nvidia_fabric_manager.sh
+++ b/ubuntu/common/install_nvidia_fabric_manager.sh
@@ -6,9 +6,9 @@ set -ex
 VERSION=$1
 
 # Install nvidia fabric manager
-NVIDIA_FABRIC_MANAGER_VERSION="510_510.73.08-1"
+NVIDIA_FABRIC_MANAGER_VERSION="510_510.85.02-1"
 NVIDIA_FABRIC_MNGR_URL=http://developer.download.nvidia.com/compute/cuda/repos/ubuntu${VERSION}/x86_64/nvidia-fabricmanager-${NVIDIA_FABRIC_MANAGER_VERSION}_amd64.deb
-$COMMON_DIR/download_and_verify.sh $NVIDIA_FABRIC_MNGR_URL "872094f7aefd587e3b8c729cc025f44cffb91ba6187ab50cf30958616eab5656"
+$COMMON_DIR/download_and_verify.sh $NVIDIA_FABRIC_MNGR_URL "64634872a8ae79e12a8eb4ae476fda8e4c32b57279475b8e299589eeaae5b1a2"
 apt install -y ./nvidia-fabricmanager-${NVIDIA_FABRIC_MANAGER_VERSION}_amd64.deb
 sudo apt-mark hold nvidia-fabricmanager-510
 $COMMON_DIR/write_component_version.sh "NVIDIA_FABRIC_MANAGER" ${NVIDIA_FABRIC_MANAGER_VERSION}

--- a/ubuntu/common/install_nvidiagpudriver.sh
+++ b/ubuntu/common/install_nvidiagpudriver.sh
@@ -7,7 +7,7 @@ CHECKSUM=$2
 
 # Reference - https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#ubuntu-installation
 # Install Cuda
-NVIDIA_VERSION="510.73.08"
+NVIDIA_VERSION="510.85.02"
 if [ ${RELEASE_VERSION} == "1804" ]; then CUDA_VERSION="11.6"; else CUDA_VERSION="11-6"; fi
 wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${RELEASE_VERSION}/x86_64/cuda-ubuntu${RELEASE_VERSION}-keyring.gpg 
 mv cuda-ubuntu${RELEASE_VERSION}-keyring.gpg /usr/share/keyrings/cuda-archive-keyring.gpg
@@ -35,7 +35,7 @@ popd
 
 # Nvidia driver
 NVIDIA_DRIVER_URL=https://us.download.nvidia.com/tesla/${NVIDIA_VERSION}/NVIDIA-Linux-x86_64-${NVIDIA_VERSION}.run
-$COMMON_DIR/download_and_verify.sh $NVIDIA_DRIVER_URL "c854bb2dc3368c0127dc08a85bd902f8558a5149085af13d061c612cf06c2913"
+$COMMON_DIR/download_and_verify.sh $NVIDIA_DRIVER_URL "372427e633f32cff6dd76020e8ed471ef825d38878bd9655308b6efea1051090"
 bash NVIDIA-Linux-x86_64-${NVIDIA_VERSION}.run --silent --dkms
 $COMMON_DIR/write_component_version.sh "NVIDIA" ${NVIDIA_VERSION}
 

--- a/ubuntu/common/install_utils.sh
+++ b/ubuntu/common/install_utils.sh
@@ -31,9 +31,11 @@ apt-get -y install numactl \
                    cmake \
                    libnl-3-dev \
                    libnl-route-3-dev \
+                   net-tools \
                    libsecret-1-0 \
+		   ansible \
+		   python3-pip \
                    dkms \
-                   python3-pip \
                    jq
 
 # Install azcopy tool 

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-LTS-hpc/install.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-LTS-hpc/install.sh
@@ -5,7 +5,7 @@ set -ex
 source ./set_properties.sh
 
 # install utils
-./install_utils.sh
+$UBUNTU_COMMON_DIR/install_utils.sh
 
 # install mellanox ofed
 ./install_mellanoxofed.sh

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_utils.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_utils.sh
@@ -10,6 +10,9 @@ cp ./microsoft-prod.list /etc/apt/sources.list.d/
 curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
 cp ./microsoft.gpg /etc/apt/trusted.gpg.d/
 
+#install apt pckages
+$UBUNTU_COMMON_DIR/install_utils.sh
+
 apt-get update
 apt-get install -y python3.8
 update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
@@ -25,50 +28,3 @@ apt-get install -y libpython3.8-dev
 apt-get install -y libgirepository1.0-dev
 python3.8 -m pip install --ignore-installed PyGObject
 apt-get install -y software-properties-common
-
-apt-get -y install build-essential
-apt-get -y install numactl \
-                   rpm \
-                   libnuma-dev \
-                   libmpc-dev \
-                   libmpfr-dev \
-                   libxml2-dev \
-                   m4 \
-                   byacc \
-                   python-dev \
-                   python-setuptools \
-                   tcl \
-                   environment-modules \
-                   tk \
-                   texinfo \
-                   libudev-dev \
-                   binutils \
-                   binutils-dev \
-                   selinux-policy-dev \
-                   flex \
-                   libnl-3-dev \
-                   libnl-route-3-dev \
-                   libnl-3-200 \
-                   bison \
-                   libnl-route-3-200 \
-                   gfortran \
-                   cmake \
-                   libnl-3-dev \
-                   libnl-route-3-dev \
-                   libsecret-1-0 \
-		   ansible \
-                   dkms \
-                   jq
-
-# Install azcopy tool 
-# To copy blobs or files to or from a storage account.
-wget https://azcopyvnextrelease.blob.core.windows.net/release20210920/azcopy_linux_se_amd64_10.12.2.tar.gz
-tar -xvf azcopy_linux_se_amd64_10.12.2.tar.gz
-
-# copy the azcopy to the bin path
-pushd azcopy_linux_se_amd64_10.12.2
-cp azcopy /usr/bin/
-popd
-
-# Allow execute permissions
-chmod +x /usr/bin/azcopy

--- a/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_utils.sh
+++ b/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_utils.sh
@@ -10,52 +10,5 @@ cp ./microsoft-prod.list /etc/apt/sources.list.d/
 curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
 cp ./microsoft.gpg /etc/apt/trusted.gpg.d/
 
-apt-get update
-apt-get -y install build-essential
-apt-get -y install numactl \
-                   rpm \
-                   libnuma-dev \
-                   libmpc-dev \
-                   libmpfr-dev \
-                   libxml2-dev \
-                   m4 \
-                   byacc \
-                   python-dev \
-                   python-setuptools \
-                   tcl \
-                   environment-modules \
-                   tk \
-                   texinfo \
-                   libudev-dev \
-                   binutils \
-                   binutils-dev \
-                   selinux-policy-dev \
-                   flex \
-                   libnl-3-dev \
-                   libnl-route-3-dev \
-                   libnl-3-200 \
-                   bison \
-                   libnl-route-3-200 \
-                   gfortran \
-                   cmake \
-                   libnl-3-dev \
-                   libnl-route-3-dev \
-                   net-tools \
-                   libsecret-1-0 \
-		   ansible \
-		   python3-pip \
-                   dkms \
-                   jq
-
-# Install azcopy tool 
-# To copy blobs or files to or from a storage account.
-wget https://azcopyvnextrelease.blob.core.windows.net/release20210920/azcopy_linux_se_amd64_10.12.2.tar.gz
-tar -xvf azcopy_linux_se_amd64_10.12.2.tar.gz
-
-# copy the azcopy to the bin path
-pushd azcopy_linux_se_amd64_10.12.2
-cp azcopy /usr/bin/
-popd
-
-# Allow execute permissions
-chmod +x /usr/bin/azcopy
+#apt-get install packages
+$UBUNTU_COMMON_DIR/install_utils.sh


### PR DESCRIPTION
There are several changes in this update.

    1. The nvidia gpu driver and fabric manager were updated to 510.85.02 to fix an infoROM corruption issue.
    2. The nccl version as updated to 2.14.3-1 to deal with a change in the
       nccl-tests.
    3. The apt installs from the ubuntu install_utils.sh files were pulled out to a ubuntu/common install_utils.sh file.
    Also the RELAXED_ORDERING setting was removed from the run-tests.sh file as it is not aplicable to all SKUs.
