### PR TITLE
Fix several issues with health-checks

### DIFF
--- a/common/copy_test_file.sh
+++ b/common/copy_test_file.sh
@@ -7,4 +7,23 @@ mkdir -p $DEST_TEST_DIR
 
 cp $TEST_DIR/run-tests.sh $DEST_TEST_DIR
 
+#Test if nvcc is installed and if so install gpu-copy test.
+if test -f "/usr/local/cuda/bin/nvcc"; then
+	#Compile the gpu-copy benchmark.
+	NVCC=/usr/local/cuda/bin/nvcc
+	cufile="$TEST_DIR/health_checks/NDv4/gpu-copy.cu"
+	outfile="$TEST_DIR/health_checks/NDv4/gpu-copy"
+
+	#Test if the default gcc compiler is new enough to compile gpu-copy.
+	#If it is not then use the 9.2 compiler, that should be installed in
+	#/opt.
+	if [ $(gcc -dumpversion | cut -d. -f1) -gt 6 ]; then
+		$NVCC -lnuma $cufile -o $outfile
+	else
+		$NVCC --compiler-bindir /opt/gcc-9.2.0/bin \
+			-lnuma $cufile -o $outfile
+	fi
+fi
+cp -r $TEST_DIR/health_checks $DEST_TEST_DIR
+
 exit 0

--- a/tests/health_checks/NDv4/ecc-errors.sh
+++ b/tests/health_checks/NDv4/ecc-errors.sh
@@ -108,7 +108,7 @@ done
 #SRAM_ECC_THRESHOLD are observed, but don't fail. 
 correctableVS=$(echo "$ECC_errors"  | grep Volatile -A 4 \
 	| grep "SRAM Correctable" | cut -d: -f2)
-CorrectableVS_v=( ${correctableVS} )
+correctableVS_v=( ${correctableVS} )
 for i in $(seq 0 $((ngpus-1))); do
 	val=$((correctableVS_v[i]))
 	if [ $val -gt $SRAM_ECC_THRESHOLD ]; then

--- a/tests/health_checks/NDv4/test-bandwidth.sh
+++ b/tests/health_checks/NDv4/test-bandwidth.sh
@@ -25,7 +25,7 @@ create_benchmark() {
         file_dir="$1"
 
         compile_bench="nvcc -lnuma $file_dir/gpu-copy.cu -o $file_dir/gpu-copy"
-        compile_error="Error when attempting to compile benchmark"
+	compile_error="**Fail** Error when attempting to compile benchmark"
         catch_error "$compile_bench" "$compile_error"
 }
 


### PR DESCRIPTION

Adding back compilation of gpu-copy executable at vm setup just so the health checks are completely setup when intallation completes. Also fixing a small bug in the ecc-errors script and making an error message created by the test-bandwidth more clear.