### PR TITLE
Image health fixes and other minor improvements (#174)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 |Ubuntu 18.04 LTS Gen1|[![Build Status](https://dev.azure.com/hpc-platform-team/hpc-image-val/_apis/build/status/hpc-image-build?branchName=master&jobName=Validate_Virtual_Machine&configuration=Validate_Virtual_Machine%20ubuntu_18.04_LTS_gen1)](https://dev.azure.com/hpc-platform-team/hpc-image-val/_build/latest?definitionId=3&branchName=master)|
 |Ubuntu 18.04 LTS Gen2|[![Build Status](https://dev.azure.com/hpc-platform-team/hpc-image-val/_apis/build/status/hpc-image-build?branchName=master&jobName=Validate_Virtual_Machine&configuration=Validate_Virtual_Machine%20ubuntu_18.04_LTS_gen2)](https://dev.azure.com/hpc-platform-team/hpc-image-val/_build/latest?definitionId=3&branchName=master)|
 |Ubuntu 20.04|[![Build Status](https://dev.azure.com/hpc-platform-team/hpc-image-val/_apis/build/status/hpc-image-build?branchName=master&jobName=Validate_Virtual_Machine&configuration=Validate_Virtual_Machine%20ubuntu_20.04)](https://dev.azure.com/hpc-platform-team/hpc-image-val/_build/latest?definitionId=3&branchName=master)
-
+|AlmaLinux 8.6|[![Build Status](https://dev.azure.com/hpc-platform-team/hpc-image-val/_apis/build/status/hpc-image-build?branchName=master&jobName=Validate_Virtual_Machine&configuration=Validate_Virtual_Machine%20alma8.6)](https://dev.azure.com/hpc-platform-team/hpc-image-val/_build/latest?definitionId=3&branchName=master)
 
 # Azhpc Images
 

--- a/alma/alma-8.x/common/install_nvidiagpudriver.sh
+++ b/alma/alma-8.x/common/install_nvidiagpudriver.sh
@@ -40,15 +40,17 @@ yum install -y rpm-build
 rpmbuild --rebuild /tmp/nvidia_peer_memory-${NV_PEER_MEMORY_VERSION}.src.rpm
 rpm -ivh ~/rpmbuild/RPMS/x86_64/nvidia_peer_memory-${NV_PEER_MEMORY_VERSION}.x86_64.rpm
 echo "exclude=nvidia_peer_memory" | tee -a /etc/yum.conf
-modprobe nv_peer_mem
-lsmod | grep nv
 popd
 
-bash -c "cat > /etc/modules-load.d/nv_peer_mem.conf" <<'EOF'
-nv_peer_mem
-EOF
+# load the nvidia-peermem coming as a part of NVIDIA GPU driver
+# Reference - https://download.nvidia.com/XFree86/Linux-x86_64/510.85.02/README/nvidia-peermem.html
+# Stop nv_peer_mem service
+service nv_peer_mem stop
+# load nvidia-peermem
+modprobe nvidia-peermem
+# verify if loaded
+lsmod | grep nvidia_peermem
 
-systemctl enable nv_peer_mem.service
 $COMMON_DIR/write_component_version.sh "NV_PEER_MEMORY" ${NV_PEER_MEMORY_VERSION}
 
 # Install GDRCopy

--- a/centos/common/install_nccl.sh
+++ b/centos/common/install_nccl.sh
@@ -36,11 +36,15 @@ popd
 # Build the nccl tests
 source /etc/profile.d/modules.sh
 module load mpi/hpcx
-git clone https://github.com/NVIDIA/nccl-tests.git
-pushd nccl-tests
+NCCL_TESTS_VERSION="2.13.3"
+TARBALL="v${NCCL_TESTS_VERSION}.tar.gz"
+NCCL_TESTS_DOWNLOAD_URL="https://github.com/NVIDIA/nccl-tests/archive/refs/tags/${TARBALL}"
+wget ${NCCL_TESTS_DOWNLOAD_URL}
+tar -xvf ${TARBALL}
+pushd nccl-tests-${NCCL_TESTS_VERSION}
 make MPI=1 MPI_HOME=${HPCX_MPI_DIR} CUDA_HOME=/usr/local/cuda
 popd
-mv nccl-tests /opt/.
+mv nccl-tests-${NCCL_TESTS_VERSION} /opt/nccl-tests
 module unload mpi/hpcx
 
 # Remove installation files

--- a/ubuntu/common/install_nv_peer_memory.sh
+++ b/ubuntu/common/install_nv_peer_memory.sh
@@ -10,20 +10,22 @@ NV_PEER_MEM_DOWNLOAD_URL="https://github.com/Mellanox/nv_peer_memory/archive/ref
 wget ${NV_PEER_MEM_DOWNLOAD_URL}
 tar -xvf $TARBALL
 
-cd nv_peer_memory-${NV_PEER_MEMORY_VERSION}
-./build_module.sh 
-cd /tmp
+pushd nv_peer_memory-${NV_PEER_MEMORY_VERSION}
+./build_module.sh
+popd
+
+pushd /tmp
 tar xzf /tmp/nvidia-peer-memory_${NV_PEER_MEMORY_VERSION_PREFIX}.orig.tar.gz
-cd nvidia-peer-memory-${NV_PEER_MEMORY_VERSION_PREFIX}/
-
+pushd nvidia-peer-memory-${NV_PEER_MEMORY_VERSION_PREFIX}/
 # Fix for issue - https://github.com/Mellanox/nv_peer_memory/issues/106
-sed -i s/1.2-0/1.3-0/g ./debian/changelog
-
+sed -i s/1.2-0/${NV_PEER_MEMORY_VERSION}/g ./debian/changelog
 dpkg-buildpackage -us -uc 
 dpkg -i ../nvidia-peer-memory_${NV_PEER_MEMORY_VERSION}_all.deb 
 apt-mark hold nvidia-peer-memory
 dpkg -i ../nvidia-peer-memory-dkms_${NV_PEER_MEMORY_VERSION}_all.deb 
 apt-mark hold nvidia-peer-memory-dkms
+popd
+popd
 
 # load the nvidia-peermem coming as a part of NVIDIA GPU driver
 # Reference - https://download.nvidia.com/XFree86/Linux-x86_64/510.85.02/README/nvidia-peermem.html

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-LTS-hpc/install_mpis.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-LTS-hpc/install_mpis.sh
@@ -44,11 +44,11 @@ sed -i "s/enable_oshmem=yes/enable_oshmem=no/" contrib/platform/mellanox/optimiz
 cd ..
 $COMMON_DIR/write_component_version.sh "OMPI" ${OMPI_VERSION}
 
-# Intel MPI 2021 (Update 6)
-IMPI_2021_VERSION="2021.6.0"
-IMPI_2021_DOWNLOAD_URL=https://registrationcenter-download.intel.com/akdlm/irc_nas/18714/l_mpi_oneapi_p_2021.6.0.602_offline.sh
-$COMMON_DIR/download_and_verify.sh $IMPI_2021_DOWNLOAD_URL "e85db63788c434d43c1378e5e2bf7927a75d11aee8e6b78ee0d933da920977a6"
-bash l_mpi_oneapi_p_2021.6.0.602_offline.sh -s -a -s --eula accept
+# Intel MPI 2021 (Update 7)
+IMPI_2021_VERSION="2021.7.0"
+IMPI_2021_DOWNLOAD_URL=https://registrationcenter-download.intel.com/akdlm/irc_nas/18926/l_mpi_oneapi_p_${IMPI_2021_VERSION}.8711_offline.sh
+$COMMON_DIR/download_and_verify.sh $IMPI_2021_DOWNLOAD_URL "4eb1e1487b67b98857bc9b7b37bcac4998e0aa6d1b892b2c87b003bf84fb38e9"
+bash l_mpi_oneapi_p_${IMPI_2021_VERSION}.8711_offline.sh -s -a -s --eula accept
 mv ${INSTALL_PREFIX}/intel/oneapi/mpi/${IMPI_2021_VERSION}/modulefiles/mpi ${INSTALL_PREFIX}/intel/oneapi/mpi/${IMPI_2021_VERSION}/modulefiles/impi
 $COMMON_DIR/write_component_version.sh "IMPI_2021" ${IMPI_2021_VERSION}
 

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_mellanoxofed.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_mellanoxofed.sh
@@ -14,3 +14,7 @@ $COMMON_DIR/write_component_version.sh "MOFED" $VERSION
 
 # Restarting openibd
 /etc/init.d/openibd restart
+
+## Fix for systemd-modules-load service failing on boot
+rm -rf /lib/modules/$(uname -r)/kernel/drivers/infiniband/ulp/iser/ib_iser.ko
+depmod


### PR DESCRIPTION
* fix for systemd-modules-load service failing on boot

* installation directory structuring for nv peer mem

* load nvidia_peermem (GPU driver) instead of nv_peer_mem for alma

* IMPI 2021 update for Ubuntu LTS

* Badge update for alma 8.6

* Release tag NCCL for CentOS 7.9