### PR TITLE
Add Lustre clients to the images.

### DIFF
--- a/alma/alma-8.x/alma-8.6-hpc/install.sh
+++ b/alma/alma-8.x/alma-8.6-hpc/install.sh
@@ -7,6 +7,10 @@ source ./set_properties.sh
 # install utils
 ./install_utils.sh
 
+# install Lustre client
+# Disable until testing is performed.
+#./install_lustre_client.sh
+
 # install compilers
 ./install_gcc.sh
 

--- a/alma/alma-8.x/alma-8.6-hpc/install_lustre_client.sh
+++ b/alma/alma-8.x/alma-8.6-hpc/install_lustre_client.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -ex
+
+DISTRIB_CODENAME=el8
+LUSTRE_VERSION=2.15.1_24_g98d1cac
+REPO_PATH=/etc/yum.repos.d/amlfs.repo
+
+rpm --import https://packages.microsoft.com/keys/microsoft.asc
+
+echo -e "[amlfs]" > ${REPO_PATH}
+echo -e "name=Azure Lustre Packages" >> ${REPO_PATH}
+echo -e "baseurl=https://packages.microsoft.com/yumrepos/amlfs-${DISTRIB_CODENAME}" >> ${REPO_PATH}
+echo -e "enabled=1" >> ${REPO_PATH}
+echo -e "gpgcheck=1" >> ${REPO_PATH}
+echo -e "gpgkey=https://packages.microsoft.com/keys/microsoft.asc" >> ${REPO_PATH}
+echo -e "exclude=lustre-client-dkms*" >> ${REPO_PATH}
+
+dnf install -y kmod-lustre-client-$(uname -r)-${LUSTRE_VERSION}-1.${DISTRIB_CODENAME}.x86_64.rpm lustre-client-${LUSTRE_VERSION}-1.${DISTRIB_CODENAME}.x86_64.rpm
+
+$COMMON_DIR/write_component_version.sh "LUSTRE" ${LUSTRE_VERSION}

--- a/ubuntu/common/hpc-tuning.sh
+++ b/ubuntu/common/hpc-tuning.sh
@@ -71,7 +71,7 @@ then
 fi
 
 # Install WALinuxAgent
-apt-get install python3-setuptools
+apt-get install -y python3-setuptools
 pip3 install distro
 WAAGENT_VERSION=2.5.0.2
 $COMMON_DIR/write_component_version.sh "WAAGENT" ${WAAGENT_VERSION}

--- a/ubuntu/common/install_docker.sh
+++ b/ubuntu/common/install_docker.sh
@@ -58,5 +58,6 @@ $COMMON_DIR/write_component_version.sh "NVIDIA-DOCKER" ${docker_version::-1}
 
 # Remove unwanted repos
 rm -f /etc/apt/sources.list.d/nvidia*
-rm -f /etc/apt/sources.list.d/microsoft-prod.list
-rm -f /etc/apt/trusted.gpg.d/microsoft.gpg
+# If you really want to get rid of the MS repos, uncomment these lines.
+#rm -f /etc/apt/sources.list.d/microsoft-prod.list
+#rm -f /etc/apt/trusted.gpg.d/microsoft.gpg

--- a/ubuntu/common/install_lustre_client.sh
+++ b/ubuntu/common/install_lustre_client.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -ex
+
+LUSTRE_VERSION=2.15.1-24-gbaa21ca
+
+source $UBUNTU_COMMON_DIR/setup_lustre_repo.sh
+
+apt-get update
+apt-get install -y amlfs-lustre-client-${LUSTRE_VERSION}=$(uname -r)
+
+$COMMON_DIR/write_component_version.sh "LUSTRE" ${LUSTRE_VERSION}

--- a/ubuntu/common/install_utils.sh
+++ b/ubuntu/common/install_utils.sh
@@ -25,6 +25,8 @@ apt-get -y install numactl \
                    libnl-3-dev \
                    libnl-route-3-dev \
                    libnl-3-200 \
+                   libnl-genl-3-dev \
+                   libnl-genl-3-200 \
                    bison \
                    libnl-route-3-200 \
                    gfortran \
@@ -33,11 +35,17 @@ apt-get -y install numactl \
                    libnl-route-3-dev \
                    net-tools \
                    libsecret-1-0 \
-		   python3-pip \
+                   python3-pip \
                    dkms \
-                   jq
+                   jq \
+                   curl \
+                   libyaml-dev \
+                   libreadline-dev \
+                   libkeyutils1 \
+                   libkeyutils-dev \
+                   libmount-dev
 
-# Install azcopy tool 
+# Install azcopy tool
 # To copy blobs or files to or from a storage account.
 VERSION="10.16.2"
 RELEASE_TAG="release20221108"

--- a/ubuntu/common/setup_lustre_repo.sh
+++ b/ubuntu/common/setup_lustre_repo.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -ex
+
+source /etc/lsb-release
+
+echo "deb [arch=amd64] https://packages.microsoft.com/repos/amlfs-${DISTRIB_CODENAME}/ ${DISTRIB_CODENAME} main" | sudo tee /etc/apt/sources.list.d/amlfs.list
+
+# Enable these lines if the MS PMC repo was not already setup.
+#curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
+#cp ./microsoft.gpg /etc/apt/trusted.gpg.d/

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-LTS-hpc/install.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-LTS-hpc/install.sh
@@ -5,7 +5,10 @@ set -ex
 source ./set_properties.sh
 
 # install utils
-$UBUNTU_COMMON_DIR/install_utils.sh
+./install_utils.sh
+
+# install Lustre client
+$UBUNTU_COMMON_DIR/install_lustre_client.sh
 
 # install mellanox ofed
 ./install_mellanoxofed.sh

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-LTS-hpc/install_utils.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-LTS-hpc/install_utils.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -ex
+
+# Setup microsoft packages repository for moby
+# Download the repository configuration package
+curl https://packages.microsoft.com/config/ubuntu/18.04/prod.list > ./microsoft-prod.list
+# Copy the generated list to the sources.list.d directory
+cp ./microsoft-prod.list /etc/apt/sources.list.d/
+# Install the Microsoft GPG public key
+curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
+cp ./microsoft.gpg /etc/apt/trusted.gpg.d/
+
+#apt-get install packages
+$UBUNTU_COMMON_DIR/install_utils.sh

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install.sh
@@ -7,6 +7,9 @@ source ./set_properties.sh
 # install utils
 ./install_utils.sh
 
+# install Lustre client
+$UBUNTU_COMMON_DIR/install_lustre_client.sh
+
 # install mellanox ofed
 ./install_mellanoxofed.sh
 

--- a/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install.sh
+++ b/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install.sh
@@ -7,6 +7,9 @@ source ./set_properties.sh
 # install utils
 ./install_utils.sh
 
+# install Lustre client
+$UBUNTU_COMMON_DIR/install_lustre_client.sh
+
 # install mellanox ofed
 ./install_mellanoxofed.sh
 


### PR DESCRIPTION
This change adds packages for Lustre for Ubuntu 18.04, 20.04, and Alma 8.6.  Alma is disabled and untested for now.
Manual testing of the new 18.04 and 20.04 scripts against a Lustre cluster indicate that they work.