### PR TITLE
H100 20.04 HPC component updates

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -35,76 +35,6 @@ source /etc/profile
 
 GCC_VERSION="9.2.0"
 
-if [ "${MOFED_LTS}" = true ]
-then
-    HPCX_VERSION_UBUNTU="v2.7.0"
-    MOFED_VERSION_UBUNTU="MLNX_OFED_LINUX-4.9-3.1.5.0"
-    HPCX_MOFED_INTEGRATION_VERSION="MLNX_OFED_LINUX-4.7-1.0.0.1"
-    HPCX_OMB_PATH_UBUNTU_1804="/opt/hpcx-${HPCX_VERSION_UBUNTU}-gcc-${HPCX_MOFED_INTEGRATION_VERSION}-ubuntu18.04-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
-    IMPI_2021_VERSION_UBUNTU="2021.7.0"
-    OMPI_VERSION_UBUNTU="4.1.3"
-else
-    HPCX_VERSION_CENTOS="v2.9.0"
-    HPCX_VERSION_UBUNTU="v2.13.1"
-    MOFED_VERSION_UBUNTU="MLNX_OFED_LINUX-5.8-1.0.1.1"
-    HPCX_MOFED_INTEGRATION_VERSION="MLNX_OFED_LINUX-5.4-1.0.3.0"
-    HPCX_OMB_PATH_UBUNTU_1804="/opt/hpcx-${HPCX_VERSION_UBUNTU}-gcc-MLNX_OFED_LINUX-5-ubuntu18.04-cuda11-gdrcopy2-nccl2.12-x86_64/ompi/tests/osu-micro-benchmarks-5.8"
-    IMPI_2021_VERSION_UBUNTU="2021.7.1"
-    OMPI_VERSION_UBUNTU="4.1.4"
-fi
-
-MVAPICH2_VERSION_CENTOS="2.3.6"
-MVAPICH2_VERSION_ALMA="2.3.7"
-MVAPICH2_VERSION_UBUNTU="2.3.7"
-OMPI_VERSION_CENTOS="4.1.1"
-OMPI_VERSION_ALMA="4.1.3"
-IMPI_2021_VERSION_CENTOS="2021.4.0"
-IMPI_2021_VERSION_ALMA="2021.7.0"
-MVAPICH2X_INSTALLATION_DIRECTORY="/opt/mvapich2-x"
-IMPI2018_PATH="/opt/intel/compilers_and_libraries_2018.5.274"
-
-MOFED_VERSION_CENTOS="MLNX_OFED_LINUX-5.4-1.0.3.0"
-MOFED_VERSION_CENTOS_79="MLNX_OFED_LINUX-5.4-3.0.0.0"
-MOFED_VERSION_CENTOS_83="MLNX_OFED_LINUX-5.2-1.0.4.0"
-MOFED_VERSION_ALMA_86="MLNX_OFED_LINUX-5.8-1.0.1.1"
-
-HPCX_OMB_PATH_CENTOS_76="/opt/hpcx-${HPCX_VERSION_CENTOS}-gcc${GCC_VERSION}-${MOFED_VERSION_CENTOS}-redhat7.6-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
-HPCX_OMB_PATH_CENTOS_77="/opt/hpcx-${HPCX_VERSION_CENTOS}-gcc${GCC_VERSION}-${MOFED_VERSION_CENTOS}-redhat7.7-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
-HPCX_OMB_PATH_CENTOS_78="/opt/hpcx-${HPCX_VERSION_CENTOS}-gcc${GCC_VERSION}-${MOFED_VERSION_CENTOS}-redhat7.8-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
-HPCX_OMB_PATH_CENTOS_79="/opt/hpcx-${HPCX_VERSION_CENTOS}-gcc${GCC_VERSION}-${HPCX_MOFED_INTEGRATION_VERSION}-redhat7.9-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
-HPCX_OMB_PATH_CENTOS_81="/opt/hpcx-${HPCX_VERSION_CENTOS}-gcc${GCC_VERSION}-${MOFED_VERSION_CENTOS}-redhat8.1-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
-HPCX_OMB_PATH_CENTOS_83="/opt/hpcx-v2.8.0-gcc-${MOFED_VERSION_CENTOS_83}-redhat8.3-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
-MODULE_FILES_ROOT_CENTOS="/usr/share/Modules/modulefiles"
-IMPI2021_PATH_CENTOS="/opt/intel/oneapi/mpi/${IMPI_2021_VERSION_CENTOS}"
-MVAPICH2_PATH_CENTOS="/opt/mvapich2-${MVAPICH2_VERSION_CENTOS}"
-MVAPICH2X_PATH_CENTOS="${MVAPICH2X_INSTALLATION_DIRECTORY}/gnu9.2.0/mofed5.1/azure-xpmem/mpirun"
-OPENMPI_PATH_CENTOS="/opt/openmpi-${OMPI_VERSION_CENTOS}"
-
-HPCX_OMB_PATH_ALMA_86="/opt/hpcx-v2.13-gcc-MLNX_OFED_LINUX-5-redhat8-cuda11-gdrcopy2-nccl2.12-x86_64/ompi/tests/osu-micro-benchmarks-5.8"
-MODULE_FILES_ROOT_ALMA="/usr/share/Modules/modulefiles"
-IMPI2021_PATH_ALMA="/opt/intel/oneapi/mpi/${IMPI_2021_VERSION_ALMA}"
-MVAPICH2_PATH_ALMA="/opt/mvapich2-${MVAPICH2_VERSION_ALMA}"
-OPENMPI_PATH_ALMA="/opt/openmpi-${OMPI_VERSION_ALMA}"
-
-MODULE_FILES_ROOT_UBUNTU="/usr/share/modules/modulefiles"
-HPCX_OMB_PATH_UBUNTU_2004="/opt/hpcx-${HPCX_VERSION_UBUNTU}-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda11-gdrcopy2-nccl2.12-x86_64/ompi/tests/osu-micro-benchmarks-5.8"
-IMPI2021_PATH_UBUNTU="/opt/intel/oneapi/mpi/${IMPI_2021_VERSION_UBUNTU}"
-MVAPICH2_PATH_UBUNTU="/opt/mvapich2-${MVAPICH2_VERSION_UBUNTU}"
-MVAPICH2X_PATH_UBUNTU="${MVAPICH2X_INSTALLATION_DIRECTORY}/gnu9.2.0/mofed5.0/advanced-xpmem/mpirun"
-OPENMPI_PATH_UBUNTU="/opt/openmpi-${OMPI_VERSION_UBUNTU}"
-
-CHECK_HPCX=0
-CHECK_IMPI_2021=0
-CHECK_IMPI_2018=0
-CHECK_OMPI=0
-CHECK_MVAPICH2=0
-CHECK_MVAPICH2X=0
-CHECK_CUDA=0
-CHECK_AOCL=1
-CHECK_NCCL=0
-CHECK_GCC=1
-CHECK_DOCKER=0
-
 # Find distro
 find_distro() {
     local os=`cat /etc/os-release | awk 'match($0, /^NAME="(.*)"/, result) { print result[1] }'`
@@ -144,7 +74,90 @@ find_ubuntu_distro() {
 distro=`find_distro`
 echo "Detected distro: ${distro}"
 
-if [[ $distro == *"CentOS Linux"* ]]; then MKL_VERSION="2021.1.1"; else MKL_VERSION="2022.1.0"; fi
+if [ "${MOFED_LTS}" = true ]
+then
+    HPCX_VERSION_UBUNTU="v2.7.0"
+    MOFED_VERSION_UBUNTU="MLNX_OFED_LINUX-4.9-3.1.5.0"
+    HPCX_MOFED_INTEGRATION_VERSION="MLNX_OFED_LINUX-4.7-1.0.0.1"
+    HPCX_OMB_PATH_UBUNTU_1804="/opt/hpcx-${HPCX_VERSION_UBUNTU}-gcc-${HPCX_MOFED_INTEGRATION_VERSION}-ubuntu18.04-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
+    IMPI_2021_VERSION_UBUNTU="2021.7.0"
+    OMPI_VERSION_UBUNTU="4.1.3"
+else
+    OMPI_VERSION_UBUNTU="4.1.4"
+    case ${distro} in
+        "Ubuntu 18.04") HPCX_VERSION_UBUNTU="v2.13.1"; 
+            MOFED_VERSION_UBUNTU="MLNX_OFED_LINUX-5.8-1.0.1.1";
+            IMPI_2021_VERSION_UBUNTU="2021.7.1";; 
+        "Ubuntu 20.04") HPCX_VERSION_UBUNTU="v2.14";
+            MOFED_VERSION_UBUNTU="MLNX_OFED_LINUX-5.9-0.5.6.0";
+            IMPI_2021_VERSION_UBUNTU="2021.8.0";;
+        *) ;;
+    esac   
+    HPCX_OMB_PATH_UBUNTU_1804="/opt/hpcx-${HPCX_VERSION_UBUNTU}-gcc-MLNX_OFED_LINUX-5-ubuntu18.04-cuda11-gdrcopy2-nccl2.12-x86_64/ompi/tests/osu-micro-benchmarks-5.8"
+fi
+
+HPCX_VERSION_CENTOS="v2.9.0"
+MVAPICH2_VERSION_CENTOS="2.3.6"
+MVAPICH2_VERSION_ALMA="2.3.7"
+MVAPICH2_VERSION_UBUNTU="2.3.7"
+OMPI_VERSION_CENTOS="4.1.1"
+OMPI_VERSION_ALMA="4.1.3"
+IMPI_2021_VERSION_CENTOS="2021.4.0"
+IMPI_2021_VERSION_ALMA="2021.7.0"
+MVAPICH2X_INSTALLATION_DIRECTORY="/opt/mvapich2-x"
+IMPI2018_PATH="/opt/intel/compilers_and_libraries_2018.5.274"
+
+MOFED_VERSION_CENTOS="MLNX_OFED_LINUX-5.4-1.0.3.0"
+MOFED_VERSION_CENTOS_79="MLNX_OFED_LINUX-5.4-3.0.0.0"
+MOFED_VERSION_CENTOS_83="MLNX_OFED_LINUX-5.2-1.0.4.0"
+MOFED_VERSION_ALMA_86="MLNX_OFED_LINUX-5.8-1.0.1.1"
+
+HPCX_OMB_PATH_CENTOS_76="/opt/hpcx-${HPCX_VERSION_CENTOS}-gcc${GCC_VERSION}-${MOFED_VERSION_CENTOS}-redhat7.6-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
+HPCX_OMB_PATH_CENTOS_77="/opt/hpcx-${HPCX_VERSION_CENTOS}-gcc${GCC_VERSION}-${MOFED_VERSION_CENTOS}-redhat7.7-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
+HPCX_OMB_PATH_CENTOS_78="/opt/hpcx-${HPCX_VERSION_CENTOS}-gcc${GCC_VERSION}-${MOFED_VERSION_CENTOS}-redhat7.8-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
+HPCX_OMB_PATH_CENTOS_79="/opt/hpcx-${HPCX_VERSION_CENTOS}-gcc${GCC_VERSION}-${HPCX_MOFED_INTEGRATION_VERSION}-redhat7.9-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
+HPCX_OMB_PATH_CENTOS_81="/opt/hpcx-${HPCX_VERSION_CENTOS}-gcc${GCC_VERSION}-${MOFED_VERSION_CENTOS}-redhat8.1-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
+HPCX_OMB_PATH_CENTOS_83="/opt/hpcx-v2.8.0-gcc-${MOFED_VERSION_CENTOS_83}-redhat8.3-x86_64/ompi/tests/osu-micro-benchmarks-5.6.2"
+MODULE_FILES_ROOT_CENTOS="/usr/share/Modules/modulefiles"
+IMPI2021_PATH_CENTOS="/opt/intel/oneapi/mpi/${IMPI_2021_VERSION_CENTOS}"
+MVAPICH2_PATH_CENTOS="/opt/mvapich2-${MVAPICH2_VERSION_CENTOS}"
+MVAPICH2X_PATH_CENTOS="${MVAPICH2X_INSTALLATION_DIRECTORY}/gnu9.2.0/mofed5.1/azure-xpmem/mpirun"
+OPENMPI_PATH_CENTOS="/opt/openmpi-${OMPI_VERSION_CENTOS}"
+
+HPCX_OMB_PATH_ALMA_86="/opt/hpcx-v2.13-gcc-MLNX_OFED_LINUX-5-redhat8-cuda11-gdrcopy2-nccl2.12-x86_64/ompi/tests/osu-micro-benchmarks-5.8"
+MODULE_FILES_ROOT_ALMA="/usr/share/Modules/modulefiles"
+IMPI2021_PATH_ALMA="/opt/intel/oneapi/mpi/${IMPI_2021_VERSION_ALMA}"
+MVAPICH2_PATH_ALMA="/opt/mvapich2-${MVAPICH2_VERSION_ALMA}"
+OPENMPI_PATH_ALMA="/opt/openmpi-${OMPI_VERSION_ALMA}"
+
+MODULE_FILES_ROOT_UBUNTU="/usr/share/modules/modulefiles"
+HPCX_OMB_PATH_UBUNTU_2004="/opt/hpcx-${HPCX_VERSION_UBUNTU}-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda11-gdrcopy2-nccl2.16-x86_64/ompi/tests/osu-micro-benchmarks-5.8"
+IMPI2021_PATH_UBUNTU="/opt/intel/oneapi/mpi/${IMPI_2021_VERSION_UBUNTU}"
+MVAPICH2_PATH_UBUNTU="/opt/mvapich2-${MVAPICH2_VERSION_UBUNTU}"
+MVAPICH2X_PATH_UBUNTU="${MVAPICH2X_INSTALLATION_DIRECTORY}/gnu9.2.0/mofed5.0/advanced-xpmem/mpirun"
+OPENMPI_PATH_UBUNTU="/opt/openmpi-${OMPI_VERSION_UBUNTU}"
+
+CHECK_HPCX=0
+CHECK_IMPI_2021=0
+CHECK_IMPI_2018=0
+CHECK_OMPI=0
+CHECK_MVAPICH2=0
+CHECK_MVAPICH2X=0
+CHECK_CUDA=0
+CHECK_AOCL=1
+CHECK_NCCL=0
+CHECK_GCC=1
+CHECK_DOCKER=0
+
+if [[ $distro == *"CentOS Linux"* ]]
+then 
+    MKL_VERSION="2021.1.1"
+elif [[ $distro == "Ubuntu 20.04" ]]
+then
+    MKL_VERSION="2023.0.0"
+else
+    MKL_VERSION="2022.1.0"
+fi
 
 if [[ $distro == "CentOS Linux 7.6.1810" ]]
 then

--- a/ubuntu/common/install_dcgm.sh
+++ b/ubuntu/common/install_dcgm.sh
@@ -5,7 +5,8 @@ set -ex
 # Reference: https://developer.nvidia.com/dcgm#Downloads
 # the repo is already added during nvidia/ cuda installations
 apt-get install -y datacenter-gpu-manager
-# $COMMON_DIR/write_component_version.sh "DCGM" ${DCGM_VERSION}
+DCGM_VERSION=$(apt list --installed | grep datacenter-gpu-manager | awk '{print $2}' | awk -F ':' '{print $2}')
+$COMMON_DIR/write_component_version.sh "DCGM" ${DCGM_VERSION}
 
 # Enable the dcgm service
 systemctl --now enable nvidia-dcgm
@@ -18,36 +19,3 @@ then
     echo "DCGM is inactive!"
     exit ${error_code}
 fi
-
-#!/bin/bash
-# set -ex
-
-# # Parameter
-# # Ubuntu Version
-# VERSION=$1
-
-# # Install DCGM
-# DCGM_VERSION=2.4.4
-# DCGM_GPUMNGR_URL=https://azhpcstor.blob.core.windows.net/azhpc-images-store/datacenter-gpu-manager_${DCGM_VERSION}_amd64.deb
-# $COMMON_DIR/download_and_verify.sh $DCGM_GPUMNGR_URL "69ba98bbc4f657f6a15a2922aee0ea6b495fad49147d056a8f442c531b885e0e"
-# dpkg -i datacenter-gpu-manager_${DCGM_VERSION}_amd64.deb && \
-# rm -f datacenter-gpu-manager_${DCGM_VERSION}_amd64.deb
-# $COMMON_DIR/write_component_version.sh "DCGM" ${DCGM_VERSION}
-
-# # Create service for dcgm to launch on bootup
-# bash -c "cat > /etc/systemd/system/dcgm.service" <<'EOF'
-# [Unit]
-# Description=DCGM service
-
-# [Service]
-# User=root
-# PrivateTmp=false
-# ExecStart=/usr/bin/nv-hostengine -n
-# Restart=on-abort
-
-# [Install]
-# WantedBy=multi-user.target
-# EOF
-
-# systemctl enable dcgm
-# systemctl start dcgm

--- a/ubuntu/common/install_dcgm.sh
+++ b/ubuntu/common/install_dcgm.sh
@@ -1,32 +1,53 @@
 #!/bin/bash
 set -ex
 
-# Parameter
-# Ubuntu Version
-VERSION=$1
-
 # Install DCGM
-DCGM_VERSION=2.4.4
-DCGM_GPUMNGR_URL=https://azhpcstor.blob.core.windows.net/azhpc-images-store/datacenter-gpu-manager_${DCGM_VERSION}_amd64.deb
-$COMMON_DIR/download_and_verify.sh $DCGM_GPUMNGR_URL "69ba98bbc4f657f6a15a2922aee0ea6b495fad49147d056a8f442c531b885e0e"
-dpkg -i datacenter-gpu-manager_${DCGM_VERSION}_amd64.deb && \
-rm -f datacenter-gpu-manager_${DCGM_VERSION}_amd64.deb
-$COMMON_DIR/write_component_version.sh "DCGM" ${DCGM_VERSION}
+# Reference: https://developer.nvidia.com/dcgm#Downloads
+# the repo is already added during nvidia/ cuda installations
+apt-get install -y datacenter-gpu-manager
+# $COMMON_DIR/write_component_version.sh "DCGM" ${DCGM_VERSION}
 
-# Create service for dcgm to launch on bootup
-bash -c "cat > /etc/systemd/system/dcgm.service" <<'EOF'
-[Unit]
-Description=DCGM service
+# Enable the dcgm service
+systemctl --now enable nvidia-dcgm
+systemctl start nvidia-dcgm
+# Check if the service is active
+systemctl is-active --quiet nvidia-dcgm
+error_code=$?
+if [ ${error_code} -ne 0 ]
+then
+    echo "DCGM is inactive!"
+    exit ${error_code}
+fi
 
-[Service]
-User=root
-PrivateTmp=false
-ExecStart=/usr/bin/nv-hostengine -n
-Restart=on-abort
+#!/bin/bash
+# set -ex
 
-[Install]
-WantedBy=multi-user.target
-EOF
+# # Parameter
+# # Ubuntu Version
+# VERSION=$1
 
-systemctl enable dcgm
-systemctl start dcgm
+# # Install DCGM
+# DCGM_VERSION=2.4.4
+# DCGM_GPUMNGR_URL=https://azhpcstor.blob.core.windows.net/azhpc-images-store/datacenter-gpu-manager_${DCGM_VERSION}_amd64.deb
+# $COMMON_DIR/download_and_verify.sh $DCGM_GPUMNGR_URL "69ba98bbc4f657f6a15a2922aee0ea6b495fad49147d056a8f442c531b885e0e"
+# dpkg -i datacenter-gpu-manager_${DCGM_VERSION}_amd64.deb && \
+# rm -f datacenter-gpu-manager_${DCGM_VERSION}_amd64.deb
+# $COMMON_DIR/write_component_version.sh "DCGM" ${DCGM_VERSION}
+
+# # Create service for dcgm to launch on bootup
+# bash -c "cat > /etc/systemd/system/dcgm.service" <<'EOF'
+# [Unit]
+# Description=DCGM service
+
+# [Service]
+# User=root
+# PrivateTmp=false
+# ExecStart=/usr/bin/nv-hostengine -n
+# Restart=on-abort
+
+# [Install]
+# WantedBy=multi-user.target
+# EOF
+
+# systemctl enable dcgm
+# systemctl start dcgm

--- a/ubuntu/common/install_docker.sh
+++ b/ubuntu/common/install_docker.sh
@@ -58,5 +58,3 @@ $COMMON_DIR/write_component_version.sh "NVIDIA-DOCKER" ${docker_version::-1}
 
 # Remove unwanted repos
 rm -f /etc/apt/sources.list.d/nvidia*
-rm -f /etc/apt/sources.list.d/microsoft-prod.list
-rm -f /etc/apt/trusted.gpg.d/microsoft.gpg

--- a/ubuntu/common/install_intel_libs.sh
+++ b/ubuntu/common/install_intel_libs.sh
@@ -7,13 +7,15 @@ VERSION=$1
 # Intel® oneAPI Math Kernel Library
 case ${VERSION} in
     1804) INTEL_MKL_VERSION="2022.1.0.223";
+        RELEASE_VERSION="18721";
         CHECKSUM="4b325a3c4c56e52f4ce6c8fbb55d7684adc16425000afc860464c0f29ea4563e";; 
     2004) INTEL_MKL_VERSION="2023.0.0.25398";
+        RELEASE_VERSION="19138";
         CHECKSUM="0d61188e91a57bdb575782eb47a05ae99ea8eebefee6b2dfe20c6708e16e9927";;
     *) ;;
 esac
 
-ONE_MKL_DOWNLOAD_URL=https://registrationcenter-download.intel.com/akdlm/irc_nas/18721/l_onemkl_p_${INTEL_MKL_VERSION}_offline.sh
+ONE_MKL_DOWNLOAD_URL=https://registrationcenter-download.intel.com/akdlm/irc_nas/${RELEASE_VERSION}/l_onemkl_p_${INTEL_MKL_VERSION}_offline.sh
 $COMMON_DIR/write_component_version.sh "INTEL_ONE_MKL" ${INTEL_MKL_VERSION}
 $COMMON_DIR/download_and_verify.sh ${ONE_MKL_DOWNLOAD_URL} ${CHECKSUM}
 sh ./l_onemkl_p_${INTEL_MKL_VERSION}_offline.sh -s -a -s --eula accept

--- a/ubuntu/common/install_intel_libs.sh
+++ b/ubuntu/common/install_intel_libs.sh
@@ -1,10 +1,19 @@
 #!/bin/bash
 set -ex
 
+# PARAMETER
+VERSION=$1
 
 # Intel® oneAPI Math Kernel Library
-VERSION="2022.1.0.223"
-ONE_MKL_DOWNLOAD_URL=https://registrationcenter-download.intel.com/akdlm/irc_nas/18721/l_onemkl_p_${VERSION}_offline.sh
-$COMMON_DIR/write_component_version.sh "INTEL_ONE_MKL" $VERSION
-$COMMON_DIR/download_and_verify.sh ${ONE_MKL_DOWNLOAD_URL} "4b325a3c4c56e52f4ce6c8fbb55d7684adc16425000afc860464c0f29ea4563e"
-sh ./l_onemkl_p_${VERSION}_offline.sh -s -a -s --eula accept
+case ${VERSION} in
+    1804) INTEL_MKL_VERSION="2022.1.0.223";
+        CHECKSUM="4b325a3c4c56e52f4ce6c8fbb55d7684adc16425000afc860464c0f29ea4563e";; 
+    2004) INTEL_MKL_VERSION="2023.0.0.25398";
+        CHECKSUM="0d61188e91a57bdb575782eb47a05ae99ea8eebefee6b2dfe20c6708e16e9927";;
+    *) ;;
+esac
+
+ONE_MKL_DOWNLOAD_URL=https://registrationcenter-download.intel.com/akdlm/irc_nas/18721/l_onemkl_p_${INTEL_MKL_VERSION}_offline.sh
+$COMMON_DIR/write_component_version.sh "INTEL_ONE_MKL" ${INTEL_MKL_VERSION}
+$COMMON_DIR/download_and_verify.sh ${ONE_MKL_DOWNLOAD_URL} ${CHECKSUM}
+sh ./l_onemkl_p_${INTEL_MKL_VERSION}_offline.sh -s -a -s --eula accept

--- a/ubuntu/common/install_mpis.sh
+++ b/ubuntu/common/install_mpis.sh
@@ -11,10 +11,10 @@ set GCC=/usr/bin/gcc
 
 INSTALL_PREFIX=/opt
 
-# HPC-X v2.13.1
-HPCX_VERSION="v2.13.1"
-TARBALL="hpcx-${HPCX_VERSION}-gcc-MLNX_OFED_LINUX-5-ubuntu${RELEASE_VERSION}-cuda11-gdrcopy2-nccl2.12-x86_64.tbz"
-HPCX_DOWNLOAD_URL=https://azhpcstor.blob.core.windows.net/azhpc-images-store/${TARBALL}
+# HPC-X v2.14
+HPCX_VERSION="v2.14"
+TARBALL="hpcx-${HPCX_VERSION}-gcc-MLNX_OFED_LINUX-5-ubuntu${RELEASE_VERSION}-cuda11-gdrcopy2-nccl2.16-x86_64.tbz"
+HPCX_DOWNLOAD_URL=https://content.mellanox.com/hpc/hpc-x/${HPCX_VERSION}/${TARBALL}
 HPCX_FOLDER=$(basename ${HPCX_DOWNLOAD_URL} .tbz)
 
 $COMMON_DIR/download_and_verify.sh ${HPCX_DOWNLOAD_URL} ${HPCX_CHECKSUM}
@@ -43,11 +43,11 @@ cd openmpi-${OMPI_VERSION}
 cd ..
 $COMMON_DIR/write_component_version.sh "OMPI" ${OMPI_VERSION}
 
-# Intel MPI 2021 (Update 7)
-IMPI_2021_VERSION="2021.7.1"
-IMPI_2021_DOWNLOAD_URL=https://registrationcenter-download.intel.com/akdlm/irc_nas/19010/l_mpi_oneapi_p_${IMPI_2021_VERSION}.16815_offline.sh
-$COMMON_DIR/download_and_verify.sh $IMPI_2021_DOWNLOAD_URL "90e7804f2367d457cd4cbf7aa29f1c5676287aa9b34f93e7c9a19e4b8583fff7"
-bash l_mpi_oneapi_p_${IMPI_2021_VERSION}.16815_offline.sh -s -a -s --eula accept
+# Intel MPI 2021 (Update 8)
+IMPI_2021_VERSION="2021.8.0"
+IMPI_2021_DOWNLOAD_URL=https://registrationcenter-download.intel.com/akdlm/irc_nas/19131/l_mpi_oneapi_p_${IMPI_2021_VERSION}.25329_offline.sh
+$COMMON_DIR/download_and_verify.sh $IMPI_2021_DOWNLOAD_URL "0fcb1171fc42fd4b2d863ae474c0b0f656b0fa1fdc1df435aa851ccd6d1eaaf7"
+bash l_mpi_oneapi_p_${IMPI_2021_VERSION}.25329_offline.sh -s -a -s --eula accept
 mv ${INSTALL_PREFIX}/intel/oneapi/mpi/${IMPI_2021_VERSION}/modulefiles/mpi ${INSTALL_PREFIX}/intel/oneapi/mpi/${IMPI_2021_VERSION}/modulefiles/impi
 $COMMON_DIR/write_component_version.sh "IMPI_2021" ${IMPI_2021_VERSION}
 

--- a/ubuntu/common/install_nccl.sh
+++ b/ubuntu/common/install_nccl.sh
@@ -3,8 +3,18 @@ set -ex
 
 # Install NCCL
 apt install -y build-essential devscripts debhelper fakeroot
-NCCL_VERSION="2.15.1-1"
-CUDA_VERSION="11.8"
+
+#PARAMETER
+VERSION=$1
+
+case ${VERSION} in
+    1804) NCCL_VERSION="2.15.1-1"; 
+        CUDA_VERSION="11.8";;
+    2004) NCCL_VERSION="2.16.5-1"; 
+        CUDA_VERSION="12.0";;
+    *) ;;
+esac
+
 TARBALL="v${NCCL_VERSION}.tar.gz"
 NCCL_DOWNLOAD_URL=https://github.com/NVIDIA/nccl/archive/refs/tags/${TARBALL}
 pushd /tmp

--- a/ubuntu/common/install_nvidia_fabric_manager.sh
+++ b/ubuntu/common/install_nvidia_fabric_manager.sh
@@ -6,9 +6,18 @@ set -ex
 VERSION=$1
 
 # Install nvidia fabric manager
-NVIDIA_FABRIC_MANAGER_VERSION="520_520.61.05-1"
+case ${VERSION} in
+    1804) NVIDIA_FABRIC_MANAGER_VERSION="520_520.61.05-1"; 
+        CHECKSUM="8beeb76ade836327298337b4f65eb3906498cebe71ab35bca5bb1a638c1bfd0a";
+        VERSION_PREFIX="520";; 
+    2004) NVIDIA_FABRIC_MANAGER_VERSION="525_525.85.12-1"; 
+        CHECKSUM="77e2f8768e4901114c35582b530b10fe6bd3b924862a929f96fc83aee078b12c";
+        VERSION_PREFIX="525";;
+    *) ;;
+esac
+
 NVIDIA_FABRIC_MNGR_URL=http://developer.download.nvidia.com/compute/cuda/repos/ubuntu${VERSION}/x86_64/nvidia-fabricmanager-${NVIDIA_FABRIC_MANAGER_VERSION}_amd64.deb
-$COMMON_DIR/download_and_verify.sh $NVIDIA_FABRIC_MNGR_URL "8beeb76ade836327298337b4f65eb3906498cebe71ab35bca5bb1a638c1bfd0a"
+$COMMON_DIR/download_and_verify.sh $NVIDIA_FABRIC_MNGR_URL ${CHECKSUM}
 apt install -y ./nvidia-fabricmanager-${NVIDIA_FABRIC_MANAGER_VERSION}_amd64.deb
-sudo apt-mark hold nvidia-fabricmanager-520
+apt-mark hold nvidia-fabricmanager-${VERSION_PREFIX}
 $COMMON_DIR/write_component_version.sh "NVIDIA_FABRIC_MANAGER" ${NVIDIA_FABRIC_MANAGER_VERSION}

--- a/ubuntu/common/install_nvidiagpudriver.sh
+++ b/ubuntu/common/install_nvidiagpudriver.sh
@@ -2,19 +2,24 @@
 set -ex
 
 # Parameters
-RELEASE_VERSION=$1
-CHECKSUM=$2
+VERSION=$1
+
+case ${VERSION} in
+    1804) NVIDIA_VERSION="520.61.05"; 
+        CUDA_VERSION="11.8"; 
+        CUDA_SAMPLES_VERSION="11.8";
+        CHECKSUM="10f6166703aeaffea237fa2d0ccacd0e9357af59b3bbc708a9097c9578509735";; 
+    2004) NVIDIA_VERSION="525.85.12"; 
+        CUDA_VERSION="12-0"; 
+        CUDA_SAMPLES_VERSION="12.0";
+        CHECKSUM="423b1d078e6385182f48c6e201e834b2eea193a622e04d613aa2259fce6e2266";;
+    *) ;;
+esac
 
 # Reference - https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#ubuntu-installation
 # Install Cuda
-NVIDIA_VERSION="520.61.05"
-if [ ${RELEASE_VERSION} == "1804" ]; then CUDA_VERSION="11.8"; else CUDA_VERSION="11-8"; fi
-wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${RELEASE_VERSION}/x86_64/cuda-ubuntu${RELEASE_VERSION}-keyring.gpg 
-mv cuda-ubuntu${RELEASE_VERSION}-keyring.gpg /usr/share/keyrings/cuda-archive-keyring.gpg
-
-echo "deb [signed-by=/usr/share/keyrings/cuda-archive-keyring.gpg] https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${RELEASE_VERSION}/x86_64/ /" | sudo tee /etc/apt/sources.list.d/cuda-ubuntu${RELEASE_VERSION}-x86_64.list
-wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${RELEASE_VERSION}/x86_64/cuda-ubuntu${RELEASE_VERSION}.pin
-mv cuda-ubuntu${RELEASE_VERSION}.pin /etc/apt/preferences.d/cuda-repository-pin-600
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${VERSION}/x86_64/cuda-keyring_1.0-1_all.deb
+dpkg -i ./cuda-keyring_1.0-1_all.deb
 
 apt-get update
 apt install -y cuda-toolkit-${CUDA_VERSION}
@@ -23,19 +28,17 @@ echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64' | tee -a /e
 $COMMON_DIR/write_component_version.sh "CUDA" ${CUDA_VERSION}
 
 # Download CUDA samples
-CUDA_SAMPLES_VERSION="11.8"
 TARBALL="v${CUDA_SAMPLES_VERSION}.tar.gz"
 CUDA_SAMPLES_DOWNLOAD_URL=https://github.com/NVIDIA/cuda-samples/archive/refs/tags/${TARBALL}
 wget ${CUDA_SAMPLES_DOWNLOAD_URL}
 tar -xvf ${TARBALL}
 pushd ./cuda-samples-${CUDA_SAMPLES_VERSION}
 make
-mkdir -p /usr/local/cuda-${CUDA_SAMPLES_VERSION}/samples/
-cp -r ./Samples/* /usr/local/cuda-${CUDA_SAMPLES_VERSION}/samples/
+mv ./Samples/ /usr/local/cuda-${CUDA_SAMPLES_VERSION}/    
 popd
 
 # Nvidia driver
 NVIDIA_DRIVER_URL=https://us.download.nvidia.com/tesla/${NVIDIA_VERSION}/NVIDIA-Linux-x86_64-${NVIDIA_VERSION}.run
-$COMMON_DIR/download_and_verify.sh $NVIDIA_DRIVER_URL "10f6166703aeaffea237fa2d0ccacd0e9357af59b3bbc708a9097c9578509735"
+$COMMON_DIR/download_and_verify.sh $NVIDIA_DRIVER_URL ${CHECKSUM}
 bash NVIDIA-Linux-x86_64-${NVIDIA_VERSION}.run --silent --dkms
 $COMMON_DIR/write_component_version.sh "NVIDIA" ${NVIDIA_VERSION}

--- a/ubuntu/common/install_utils.sh
+++ b/ubuntu/common/install_utils.sh
@@ -39,8 +39,9 @@ apt-get -y install numactl \
 
 # Install azcopy tool 
 # To copy blobs or files to or from a storage account.
-VERSION="10.16.2"
-RELEASE_TAG="release20221108"
+# Parameters - Version, Release Tag
+VERSION=$1
+RELEASE_TAG=$2
 TARBALL="azcopy_linux_amd64_${VERSION}.tar.gz"
 AZCOPY_DOWNLOAD_URL="https://azcopyvnext.azureedge.net/${RELEASE_TAG}/${TARBALL}"
 AZCOPY_FOLDER=$(basename ${AZCOPY_DOWNLOAD_URL} .tgz)

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-LTS-hpc/install.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-LTS-hpc/install.sh
@@ -27,7 +27,7 @@ rm -Rf -- */
 $UBUNTU_COMMON_DIR/install_dcgm.sh 1804
 
 # install Intel libraries
-$UBUNTU_COMMON_DIR/install_intel_libs.sh
+$UBUNTU_COMMON_DIR/install_intel_libs.sh 1804
 
 # install diagnostic script
 $COMMON_DIR/install_hpcdiag.sh

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-LTS-hpc/install.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-LTS-hpc/install.sh
@@ -24,7 +24,7 @@ rm -rf *.tgz *.bz2 *.tbz *.tar.gz *.run *.deb *_offline.sh
 rm -Rf -- */
 
 # Install DCGM
-$UBUNTU_COMMON_DIR/install_dcgm.sh 1804
+$UBUNTU_COMMON_DIR/install_dcgm.sh
 
 # install Intel libraries
 $UBUNTU_COMMON_DIR/install_intel_libs.sh 1804

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-LTS-hpc/install.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-LTS-hpc/install.sh
@@ -5,7 +5,7 @@ set -ex
 source ./set_properties.sh
 
 # install utils
-$UBUNTU_COMMON_DIR/install_utils.sh
+./install_utils.sh
 
 # install mellanox ofed
 ./install_mellanoxofed.sh

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-LTS-hpc/install_nccl.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-LTS-hpc/install_nccl.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # Skip installation of NCCL RDMA sharp plugin for CX-3 pro
-sed -i '25,33 s/^/#/' $UBUNTU_COMMON_DIR/install_nccl.sh
-$UBUNTU_COMMON_DIR/install_nccl.sh
+sed -i '36,44 s/^/#/' $UBUNTU_COMMON_DIR/install_nccl.sh
+$UBUNTU_COMMON_DIR/install_nccl.sh 1804

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-LTS-hpc/install_nvidiagpudriver.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-LTS-hpc/install_nvidiagpudriver.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -ex
 
-$UBUNTU_COMMON_DIR/install_nvidiagpudriver.sh 1804 "b8db71bf86c4b282a96efcb56d6b1bc48df13117b1a46c3e457628fd401587cc"
+$UBUNTU_COMMON_DIR/install_nvidiagpudriver.sh 1804

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-LTS-hpc/install_utils.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-LTS-hpc/install_utils.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -ex
+
+AZCOPY_VERSION="10.16.2"
+AZCOPY_RELEASE_TAG="release20221108"
+$UBUNTU_COMMON_DIR/install_utils.sh ${AZCOPY_VERSION} ${AZCOPY_RELEASE_TAG}

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install.sh
@@ -17,7 +17,7 @@ source ./set_properties.sh
 ./install_nvidiagpudriver.sh
 
 # Install NCCL
-$UBUNTU_COMMON_DIR/install_nccl.sh
+$UBUNTU_COMMON_DIR/install_nccl.sh 1804
 
 # Install NVIDIA docker container
 $UBUNTU_COMMON_DIR/install_docker.sh

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install.sh
@@ -27,7 +27,7 @@ rm -rf *.tgz *.bz2 *.tbz *.tar.gz *.run *.deb *_offline.sh
 rm -Rf -- */
 
 # Install DCGM
-$UBUNTU_COMMON_DIR/install_dcgm.sh 1804
+$UBUNTU_COMMON_DIR/install_dcgm.sh
 
 # install Intel libraries
 $UBUNTU_COMMON_DIR/install_intel_libs.sh 1804

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install.sh
@@ -30,7 +30,7 @@ rm -Rf -- */
 $UBUNTU_COMMON_DIR/install_dcgm.sh 1804
 
 # install Intel libraries
-$UBUNTU_COMMON_DIR/install_intel_libs.sh
+$UBUNTU_COMMON_DIR/install_intel_libs.sh 1804
 
 # install diagnostic script
 $COMMON_DIR/install_hpcdiag.sh

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_mpis.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_mpis.sh
@@ -1,5 +1,117 @@
 #!/bin/bash
 set -ex
 
-# Install common MPIs for Ubuntu
-$UBUNTU_COMMON_DIR/install_mpis.sh 18.04 "4fc27012dd9f359c919ee4e681a8a41a5d5a467f40fa89b95f26b7a4106bf1b9"
+# Load gcc
+set CC=/usr/bin/gcc
+set GCC=/usr/bin/gcc
+
+INSTALL_PREFIX=/opt
+
+# HPC-X v2.13.1
+HPCX_VERSION="v2.13.1"
+TARBALL="hpcx-${HPCX_VERSION}-gcc-MLNX_OFED_LINUX-5-ubuntu18.04-cuda11-gdrcopy2-nccl2.12-x86_64.tbz"
+HPCX_DOWNLOAD_URL=https://azhpcstor.blob.core.windows.net/azhpc-images-store/${TARBALL}
+HPCX_FOLDER=$(basename ${HPCX_DOWNLOAD_URL} .tbz)
+
+$COMMON_DIR/download_and_verify.sh ${HPCX_DOWNLOAD_URL} "4fc27012dd9f359c919ee4e681a8a41a5d5a467f40fa89b95f26b7a4106bf1b9"
+tar -xvf ${TARBALL}
+mv ${HPCX_FOLDER} ${INSTALL_PREFIX}
+HPCX_PATH=${INSTALL_PREFIX}/${HPCX_FOLDER}
+$COMMON_DIR/write_component_version.sh "HPCX" $HPCX_VERSION
+
+# MVAPICH2 2.3.7
+MV2_VERSION="2.3.7"
+MV2_DOWNLOAD_URL=http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-${MV2_VERSION}.tar.gz
+$COMMON_DIR/download_and_verify.sh $MV2_DOWNLOAD_URL "c39a4492f4be50df6100785748ba2894e23ce450a94128181d516da5757751ae"
+tar -xvf mvapich2-${MV2_VERSION}.tar.gz
+cd mvapich2-${MV2_VERSION}
+./configure --prefix=${INSTALL_PREFIX}/mvapich2-${MV2_VERSION} --enable-g=none --enable-fast=yes && make -j$(nproc) && make install
+cd ..
+$COMMON_DIR/write_component_version.sh "MVAPICH2" ${MV2_VERSION}
+
+# OpenMPI 4.1.4
+OMPI_VERSION="4.1.4"
+OMPI_DOWNLOAD_URL=https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-${OMPI_VERSION}.tar.gz
+$COMMON_DIR/download_and_verify.sh $OMPI_DOWNLOAD_URL "e166dbe876e13a50c2882e11193fecbc4362e89e6e7b6deeb69bf095c0f4fc4c"
+tar -xvf openmpi-${OMPI_VERSION}.tar.gz
+cd openmpi-${OMPI_VERSION}
+./configure --prefix=${INSTALL_PREFIX}/openmpi-${OMPI_VERSION} --with-ucx=${UCX_PATH} --with-hcoll=${HCOLL_PATH} --enable-mpirun-prefix-by-default --with-platform=contrib/platform/mellanox/optimized && make -j$(nproc) && make install
+cd ..
+$COMMON_DIR/write_component_version.sh "OMPI" ${OMPI_VERSION}
+
+# Intel MPI 2021 (Update 7)
+IMPI_2021_VERSION="2021.7.1"
+IMPI_2021_DOWNLOAD_URL=https://registrationcenter-download.intel.com/akdlm/irc_nas/19010/l_mpi_oneapi_p_${IMPI_2021_VERSION}.16815_offline.sh
+$COMMON_DIR/download_and_verify.sh $IMPI_2021_DOWNLOAD_URL "90e7804f2367d457cd4cbf7aa29f1c5676287aa9b34f93e7c9a19e4b8583fff7"
+bash l_mpi_oneapi_p_${IMPI_2021_VERSION}.16815_offline.sh -s -a -s --eula accept
+mv ${INSTALL_PREFIX}/intel/oneapi/mpi/${IMPI_2021_VERSION}/modulefiles/mpi ${INSTALL_PREFIX}/intel/oneapi/mpi/${IMPI_2021_VERSION}/modulefiles/impi
+$COMMON_DIR/write_component_version.sh "IMPI_2021" ${IMPI_2021_VERSION}
+
+# Module Files
+MODULE_FILES_DIRECTORY=/usr/share/modules/modulefiles/mpi
+mkdir -p ${MODULE_FILES_DIRECTORY}
+
+# HPC-X
+cat << EOF >> ${MODULE_FILES_DIRECTORY}/hpcx-${HPCX_VERSION}
+#%Module 1.0
+#
+#  HPCx ${HPCX_VERSION}
+#
+conflict        mpi
+module load ${HPCX_PATH}/modulefiles/hpcx
+EOF
+
+# MVAPICH2
+cat << EOF >> ${MODULE_FILES_DIRECTORY}/mvapich2-${MV2_VERSION}
+#%Module 1.0
+#
+#  MVAPICH2 ${MV2_VERSION}
+#
+conflict        mpi
+prepend-path    PATH            /opt/mvapich2-${MV2_VERSION}/bin
+prepend-path    LD_LIBRARY_PATH /opt/mvapich2-${MV2_VERSION}/lib
+prepend-path    MANPATH         /opt/mvapich2-${MV2_VERSION}/share/man
+setenv          MPI_BIN         /opt/mvapich2-${MV2_VERSION}/bin
+setenv          MPI_INCLUDE     /opt/mvapich2-${MV2_VERSION}/include
+setenv          MPI_LIB         /opt/mvapich2-${MV2_VERSION}/lib
+setenv          MPI_MAN         /opt/mvapich2-${MV2_VERSION}/share/man
+setenv          MPI_HOME        /opt/mvapich2-${MV2_VERSION}
+EOF
+
+# OpenMPI
+cat << EOF >> ${MODULE_FILES_DIRECTORY}/openmpi-${OMPI_VERSION}
+#%Module 1.0
+#
+#  OpenMPI ${OMPI_VERSION}
+#
+conflict        mpi
+prepend-path    PATH            /opt/openmpi-${OMPI_VERSION}/bin
+prepend-path    LD_LIBRARY_PATH /opt/openmpi-${OMPI_VERSION}/lib
+prepend-path    MANPATH         /opt/openmpi-${OMPI_VERSION}/share/man
+setenv          MPI_BIN         /opt/openmpi-${OMPI_VERSION}/bin
+setenv          MPI_INCLUDE     /opt/openmpi-${OMPI_VERSION}/include
+setenv          MPI_LIB         /opt/openmpi-${OMPI_VERSION}/lib
+setenv          MPI_MAN         /opt/openmpi-${OMPI_VERSION}/share/man
+setenv          MPI_HOME        /opt/openmpi-${OMPI_VERSION}
+EOF
+
+# Intel 2021
+cat << EOF >> ${MODULE_FILES_DIRECTORY}/impi_${IMPI_2021_VERSION}
+#%Module 1.0
+#
+#  Intel MPI ${IMPI_2021_VERSION}
+#
+conflict        mpi
+module load /opt/intel/oneapi/mpi/${IMPI_2021_VERSION}/modulefiles/impi
+setenv          MPI_BIN         /opt/intel/oneapi/mpi/${IMPI_2021_VERSION}/bin
+setenv          MPI_INCLUDE     /opt/intel/oneapi/mpi/${IMPI_2021_VERSION}/include
+setenv          MPI_LIB         /opt/intel/oneapi/mpi/${IMPI_2021_VERSION}/lib
+setenv          MPI_MAN         /opt/intel/oneapi/mpi/${IMPI_2021_VERSION}/man
+setenv          MPI_HOME        /opt/intel/oneapi/mpi/${IMPI_2021_VERSION}
+EOF
+
+# Softlinks
+ln -s ${MODULE_FILES_DIRECTORY}/hpcx-${HPCX_VERSION} ${MODULE_FILES_DIRECTORY}/hpcx
+ln -s ${MODULE_FILES_DIRECTORY}/mvapich2-${MV2_VERSION} ${MODULE_FILES_DIRECTORY}/mvapich2
+ln -s ${MODULE_FILES_DIRECTORY}/openmpi-${OMPI_VERSION} ${MODULE_FILES_DIRECTORY}/openmpi
+ln -s ${MODULE_FILES_DIRECTORY}/impi_${IMPI_2021_VERSION} ${MODULE_FILES_DIRECTORY}/impi-2021

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_nvidiagpudriver.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_nvidiagpudriver.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-$UBUNTU_COMMON_DIR/install_nvidiagpudriver.sh 1804 "b8db71bf86c4b282a96efcb56d6b1bc48df13117b1a46c3e457628fd401587cc"
+$UBUNTU_COMMON_DIR/install_nvidiagpudriver.sh 1804
 $UBUNTU_COMMON_DIR/install_nv_peer_memory.sh
 
 # Install gdrcopy

--- a/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_utils.sh
+++ b/ubuntu/ubuntu-18.x/ubuntu-18.04-hpc/install_utils.sh
@@ -11,7 +11,9 @@ curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microso
 cp ./microsoft.gpg /etc/apt/trusted.gpg.d/
 
 #install apt pckages
-$UBUNTU_COMMON_DIR/install_utils.sh
+AZCOPY_VERSION="10.16.2"
+AZCOPY_RELEASE_TAG="release20221108"
+$UBUNTU_COMMON_DIR/install_utils.sh ${AZCOPY_VERSION} ${AZCOPY_RELEASE_TAG}
 
 apt-get update
 apt-get install -y python3.8

--- a/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install.sh
+++ b/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install.sh
@@ -17,7 +17,7 @@ source ./set_properties.sh
 ./install_nvidiagpudriver.sh
 
 # Install NCCL
-$UBUNTU_COMMON_DIR/install_nccl.sh
+$UBUNTU_COMMON_DIR/install_nccl.sh 2004
 
 # Install NVIDIA docker container
 $UBUNTU_COMMON_DIR/install_docker.sh

--- a/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install.sh
+++ b/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install.sh
@@ -30,7 +30,7 @@ rm -Rf -- */
 $UBUNTU_COMMON_DIR/install_dcgm.sh 2004
 
 # install Intel libraries
-$UBUNTU_COMMON_DIR/install_intel_libs.sh
+$UBUNTU_COMMON_DIR/install_intel_libs.sh 2004
 
 # install diagnostic script
 $COMMON_DIR/install_hpcdiag.sh

--- a/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install.sh
+++ b/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install.sh
@@ -27,7 +27,7 @@ rm -rf *.tgz *.bz2 *.tbz *.tar.gz *.run *.deb *_offline.sh
 rm -Rf -- */
 
 # Install DCGM
-$UBUNTU_COMMON_DIR/install_dcgm.sh 2004
+$UBUNTU_COMMON_DIR/install_dcgm.sh
 
 # install Intel libraries
 $UBUNTU_COMMON_DIR/install_intel_libs.sh 2004

--- a/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_mellanoxofed.sh
+++ b/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_mellanoxofed.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 set -ex
 
-VERSION="5.8-1.0.1.1"
+VERSION="5.9-0.5.6.0"
 TARBALL="MLNX_OFED_LINUX-$VERSION-ubuntu20.04-x86_64.tgz"
 MLNX_OFED_DOWNLOAD_URL=https://content.mellanox.com/ofed/MLNX_OFED-${VERSION}/$TARBALL
 MOFED_FOLDER=$(basename ${MLNX_OFED_DOWNLOAD_URL} .tgz)
 
-$COMMON_DIR/download_and_verify.sh $MLNX_OFED_DOWNLOAD_URL "1259c867ee1805872bb2838ab12d45685f99d4a3f355def5dd9f610801a8d4b5"
+$COMMON_DIR/download_and_verify.sh $MLNX_OFED_DOWNLOAD_URL "7a7a31deecf91d5e864f23114283c77115e363c0577faf6e4b8bac8ad965d96a"
 tar zxvf ${TARBALL}
 
 ./${MOFED_FOLDER}/mlnxofedinstall --add-kernel-support --skip-unsupported-devices-check --without-fw-update

--- a/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_mpis.sh
+++ b/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_mpis.sh
@@ -2,4 +2,4 @@
 set -ex
 
 # Install common MPIs for Ubuntu
-$UBUNTU_COMMON_DIR/install_mpis.sh 20.04 "4e8c64cf00c904e0777ad60dc3bfc908648da767f7b9f3e4d5248b4818b535e5"
+$UBUNTU_COMMON_DIR/install_mpis.sh 20.04 "555f58e1114071861ea0b9e57d57ee77b18e920acea348ab5bb2fbdeb5485824"

--- a/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_nvidiagpudriver.sh
+++ b/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_nvidiagpudriver.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-$UBUNTU_COMMON_DIR/install_nvidiagpudriver.sh 2004 "f1b48828dc3233e769a5bb1518e8d8d120de5d8dd336bccc1f547b8c05887ebd"
+$UBUNTU_COMMON_DIR/install_nvidiagpudriver.sh 2004
 $UBUNTU_COMMON_DIR/install_nv_peer_memory.sh
 
 # Install gdrcopy

--- a/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_utils.sh
+++ b/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_utils.sh
@@ -11,4 +11,6 @@ curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microso
 cp ./microsoft.gpg /etc/apt/trusted.gpg.d/
 
 #apt-get install packages
-$UBUNTU_COMMON_DIR/install_utils.sh
+AZCOPY_VERSION="10.17.0"
+AZCOPY_RELEASE_TAG="release20230123"
+$UBUNTU_COMMON_DIR/install_utils.sh ${AZCOPY_VERSION} ${AZCOPY_RELEASE_TAG}


### PR DESCRIPTION
Ubuntu 20.04 HPC component configuration for H100
Component Current Version Latest available
azcopy 10.12.2 10.17.0
Mellanox OFED 5.6-1.0.3.3 5.9-0.5.6.0
HPC-x 2.11 2.14.0
MVAPICH2 2.3.7 2.3.7
OpenMPI 4.1.3 4.1.4
IMPI 2021 2021.7.0 2021.8.0
NVIDIA 520.61.05 525.85.12
CUDA 11.8 12.0
NV peer memory 1.3.0 1.3.0
GDR Copy 2.3 2.3
NCCL 2.15.1-1 2.16.5-1
DCGM 2.4.4 3.1.6
Intel One MKL 2022.1.0.223 2023.0.0