### PR TITLE
Update hpc-tuning.sh

### DIFF
--- a/ubuntu/common/hpc-tuning.sh
+++ b/ubuntu/common/hpc-tuning.sh
@@ -84,6 +84,7 @@ popd
 
 # Configure WALinuxAgent
 sed -i -e 's/# OS.EnableRDMA=y/OS.EnableRDMA=y/g' /etc/waagent.conf
+sed -i -e 's/Provisioning.MonitorHostName=n/Provisioning.MonitorHostName=y/g' /etc/waagent.conf
 echo "Extensions.GoalStatePeriod=300" | sudo tee -a /etc/waagent.conf
 echo "Extensions.InitialGoalStatePeriod=6" | sudo tee -a /etc/waagent.conf
 echo "OS.EnableFirewallPeriod=300" | sudo tee -a /etc/waagent.conf


### PR DESCRIPTION
To fix the issue of NSLookup failure on scheduler node to resolve compute node names. Details are below:

The scheduler node on CycleCloud 8.3, Slurm 22.05.03-1 (version 2.7.0) is not able to resolve the execute node names. It doesn't make any difference whether or not "Name as Hostname" is checked.  The execute nodes are able to register with DNS with no problem.  The subnet is using the default Azure DNS, and the nodes are built from the microsoft-dsvm:ubuntu-hpc:2204:latest image.

https://teams.microsoft.com/l/message/19:c8461cd323d34cfa9ab52ea64264fe4e@thread.skype/1683904218393?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=9058011a-9674-4bee-81cd-51f3cf8acd93&parentMessageId=1683904218393&teamName=Ask%20CycleCloud&channelName=General&createdTime=1683904218393