### PR TITLE
HPC-x v2.15 fix for AlmaLinux HPC 8.7

### DIFF
--- a/alma/alma-8.x/alma-8.7-hpc/install.sh
+++ b/alma/alma-8.x/alma-8.7-hpc/install.sh
@@ -61,9 +61,6 @@ $COMMON_DIR/install_hpcdiag.sh
 #install monitoring tools
 $COMMON_DIR/../alma/common/install_monitoring_tools.sh
 
-# install AMD libs
-$COMMON_DIR/../alma/common/install_amd_libs.sh
-
 # install Azure/NHC Health Checks
 $COMMON_DIR/install_health_checks.sh
 

--- a/alma/alma-8.x/alma-8.7-hpc/install_amd_libs.sh
+++ b/alma/alma-8.x/alma-8.7-hpc/install_amd_libs.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 $COMMON_DIR/../alma/alma-8.x/common/install_amd_libs.sh
+$ALMA_COMMON_DIR/install_amd_libs.sh

--- a/alma/alma-8.x/alma-8.7-hpc/install_mpis.sh
+++ b/alma/alma-8.x/alma-8.7-hpc/install_mpis.sh
@@ -14,10 +14,10 @@ INSTALL_PREFIX=/opt
 # HPC-X v2.15
 HPCX_VERSION="v2.15"
 TARBALL="hpcx-${HPCX_VERSION}-gcc-MLNX_OFED_LINUX-5-redhat8-cuda12-gdrcopy2-nccl2.17-x86_64.tbz"
-HPCX_DOWNLOAD_URL=https://content.mellanox.com/hpc/hpc-x/${HPCX_VERSION}/${TARBALL}
+HPCX_DOWNLOAD_URL=https://azhpcstor.blob.core.windows.net/azhpc-images-store/${TARBALL}
 HPCX_FOLDER=$(basename ${HPCX_DOWNLOAD_URL} .tbz)
 
-$COMMON_DIR/download_and_verify.sh $HPCX_DOWNLOAD_URL "952fa25cd3503373011e04d7a372f5aa79381d72914fc9cffc3de6b4b21dadf0"
+$COMMON_DIR/download_and_verify.sh $HPCX_DOWNLOAD_URL "0ca27ef0d6fa3d6be176f461977875030bc8cc130a784e216b1c23259c733e41"
 tar -xvf ${TARBALL}
 mv ${HPCX_FOLDER} ${INSTALL_PREFIX}
 HPCX_PATH=${INSTALL_PREFIX}/${HPCX_FOLDER}

--- a/alma/alma-8.x/common/install_utils.sh
+++ b/alma/alma-8.x/common/install_utils.sh
@@ -50,6 +50,10 @@ yum install -y numactl \
 ## Disable kernel updates
 echo "exclude=kernel* kmod*" | tee -a /etc/dnf/dnf.conf
 
+# Disable dependencies on kernel core
+sed -i "$ s/$/ shim*/" /etc/dnf/dnf.conf
+sed -i "$ s/$/ grub2*/" /etc/dnf/dnf.conf
+
 ## Install dkms from the EPEL repository
 wget -r --no-parent -A "dkms-*.el8.noarch.rpm" https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/d/
 yum localinstall ./dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/d/dkms-*.el8.noarch.rpm -y

--- a/common/install_health_checks.sh
+++ b/common/install_health_checks.sh
@@ -5,7 +5,10 @@ set -e
 
 AZHC_VERSION=v0.2.1
 
-pushd /opt/azurehpc/test/
+DEST_TEST_DIR=/opt/azurehpc/test
+mkdir -p $DEST_TEST_DIR
+
+pushd $DEST_TEST_DIR
 
 git clone https://github.com/Azure/azurehpc-health-checks.git --branch $AZHC_VERSION
 
@@ -17,4 +20,4 @@ pushd azurehpc-health-checks
 popd
 popd
 
-$COMMON_DIR/write_component_version.sh "MONEO" ${AZHC_VERSION}
+$COMMON_DIR/write_component_version.sh "AZ_HEALTH_CHECKS" ${AZHC_VERSION}


### PR DESCRIPTION
- HPC-x v2.15 fix
- Disabling additional dependencies on kernel-core
- Minor bug fixes pertaining to health checks