### PR TITLE
AZ NHC version update

### DIFF
--- a/common/install_health_checks.sh
+++ b/common/install_health_checks.sh
@@ -3,7 +3,7 @@
 
 set -e
 
-AZHC_VERSION=v0.2.5
+AZHC_VERSION=v0.2.6
 
 DEST_TEST_DIR=/opt/azurehpc/test
 AZHC_DIR=/opt/azurehpc/test/azurehpc-health-checks


### PR DESCRIPTION
- update of AZ NHC which replaces old IB loop back method so that HCA's now communicate to themselves vs a pair of HCA's communicating.
- https://github.com/Azure/azurehpc-health-checks/releases/tag/v0.2.6