### PR TITLE
fixed udev rules for nfs-readahead

### DIFF
--- a/alma/common/hpc-tuning.sh
+++ b/alma/common/hpc-tuning.sh
@@ -94,9 +94,9 @@ $COMMON_DIR/write_component_version.sh "WAAGENT" $(waagent --version | head -n 1
 #    https://learn.microsoft.com/en-us/azure/azure-netapp-files/performance-linux-nfs-read-ahead
 #    https://learn.microsoft.com/en-us/azure/storage/blobs/secure-file-transfer-protocol-support-how-to?tabs=azure-portal
 cat > /etc/udev/rules.d/90-nfs-readahead.rules <<EOM
-SUBSYSTEM=="bdi",
-ACTION=="add",
-PROGRAM="/usr/bin/awk -v bdi=$kernel 'BEGIN{ret=1} {if ($4 == bdi) {ret=0}} END{exit ret}' /proc/fs/nfsfs/volumes",
+SUBSYSTEM=="bdi", \
+ACTION=="add", \
+PROGRAM="/usr/bin/awk -v bdi=\$kernel 'BEGIN{ret=1} {if (\$4 == bdi) {ret=0}} END{exit ret}' /proc/fs/nfsfs/volumes", \
 ATTR{read_ahead_kb}="15380"
 EOM
 

--- a/ubuntu/common/hpc-tuning.sh
+++ b/ubuntu/common/hpc-tuning.sh
@@ -100,9 +100,9 @@ systemctl restart walinuxagent
 #    https://learn.microsoft.com/en-us/azure/azure-netapp-files/performance-linux-nfs-read-ahead
 #    https://learn.microsoft.com/en-us/azure/storage/blobs/secure-file-transfer-protocol-support-how-to?tabs=azure-portal
 cat > /etc/udev/rules.d/90-nfs-readahead.rules <<EOM
-SUBSYSTEM=="bdi",
-ACTION=="add",
-PROGRAM="/usr/bin/awk -v bdi=$kernel 'BEGIN{ret=1} {if ($4 == bdi) {ret=0}} END{exit ret}' /proc/fs/nfsfs/volumes",
+SUBSYSTEM=="bdi", \
+ACTION=="add", \
+PROGRAM="/usr/bin/awk -v bdi=\$kernel 'BEGIN{ret=1} {if (\$4 == bdi) {ret=0}} END{exit ret}' /proc/fs/nfsfs/volumes", \
 ATTR{read_ahead_kb}="15380"
 EOM
 


### PR DESCRIPTION
This was broken as it was split on multiple lines.  This caused errors for the first three and then applied the read ahead to every device. The way the file was written also meant that `$kernel` and `$4` were evaluated by the shell when writing the file as the $'s needed to be escaped.