### PR TITLE
remove all containers after testing docker

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -507,6 +507,7 @@ then
     sudo docker pull hello-world
     sudo docker run hello-world
     check_exit_code "Docker installed and working correctly!" "Problem with Docker!"
+    sudo docker rm $(sudo docker ps -aq)
 fi
 
 # verify mpi installations and their modulefiles


### PR DESCRIPTION
remove all docker containers after testing docker.
the hello-world containers left over from testing may trigger security policy violation.
