### PR TITLE
fix swapped values in ncv4 topo file

### DIFF
--- a/topology/ncv4-topo.xml
+++ b/topology/ncv4-topo.xml
@@ -2,7 +2,7 @@
   <cpu numaid="0" affinity="00000000,00000000,00ffffff" arch="x86_64" vendor="AuthenticAMD" familyid="175" modelid="1">
     <pci busid="0001:00:00.0" class="0x030200" vendor="0x10de" device="0x20b5" subsystem_vendor="0x10de" subsystem_device="0x1533" link_speed="" link_width="0">
       <gpu dev="0" sm="80" rank="0" gdr="1">
-        <nvlink target="0002:00:00.0" count="12" tclass="0x030200"/>
+        <nvlink target="0001:00:00.0" count="12" tclass="0x030200"/>
       </gpu>
     </pci>
     <nic>
@@ -12,21 +12,21 @@
   <cpu numaid="1" affinity="00000000,0000ffff,ff000000" arch="x86_64" vendor="AuthenticAMD" familyid="175" modelid="1">
     <pci busid="0002:00:00.0" class="0x030200" vendor="0x10de" device="0x20b5" subsystem_vendor="0x10de" subsystem_device="0x1533" link_speed="" link_width="0">
       <gpu dev="1" sm="80" rank="1" gdr="1">
-        <nvlink target="0001:00:00.0" count="12" tclass="0x030200"/>
+        <nvlink target="0002:00:00.0" count="12" tclass="0x030200"/>
       </gpu>
     </pci>
   </cpu>
   <cpu numaid="2" affinity="000000ff,ffff0000,00000000" arch="x86_64" vendor="AuthenticAMD" familyid="175" modelid="1">
     <pci busid="0003:00:00.0" class="0x030200" vendor="0x10de" device="0x20b5" subsystem_vendor="0x10de" subsystem_device="0x1533" link_speed="" link_width="0">
       <gpu dev="2" sm="80" rank="2" gdr="1">
-        <nvlink target="0004:00:00.0" count="12" tclass="0x030200"/>
+        <nvlink target="0003:00:00.0" count="12" tclass="0x030200"/>
       </gpu>
     </pci>
   </cpu>
   <cpu numaid="3" affinity="ffffff00,00000000,00000000" arch="x86_64" vendor="AuthenticAMD" familyid="175" modelid="1">
     <pci busid="0004:00:00.0" class="0x030200" vendor="0x10de" device="0x20b5" subsystem_vendor="0x10de" subsystem_device="0x1533" link_speed="" link_width="0">
       <gpu dev="3" sm="80" rank="3" gdr="1">
-        <nvlink target="0003:00:00.0" count="12" tclass="0x030200"/>
+        <nvlink target="0004:00:00.0" count="12" tclass="0x030200"/>
       </gpu>
     </pci>
   </cpu>


### PR DESCRIPTION
The GPU values for NUMA domains 1 and 2, 3 and 4, were swapped. Corrected the values and "unswapped" them. 

Ran NCCL and verified that there were no errors related to the change in topo file. Attached the results as a .txt file.
[ncv4-topo-swap-test.txt](https://github.com/Azure/azhpc-images/files/14289622/ncv4-topo-swap-test.txt)
