### PR TITLE
add the modulefiles directory in alma

### DIFF
--- a/alma/alma-8.x/alma-8.7-hpc/install_mpis.sh
+++ b/alma/alma-8.x/alma-8.7-hpc/install_mpis.sh
@@ -38,7 +38,7 @@ cp -r ${HPCX_PATH}/ompi/tests ${HPCX_PATH}/hpcx-rebuild
 sed -i "$ s/$/ ucx*/" /etc/dnf/dnf.conf
 
 # Setup module files for MPIs
-MODULE_FILES_DIRECTORY=/usr/share/modules/modulefiles/mpi
+MODULE_FILES_DIRECTORY=/usr/share/Modules/modulefiles/mpi
 mkdir -p ${MODULE_FILES_DIRECTORY}
 
 # HPC-X

--- a/alma/alma-8.x/alma-8.7-hpc/install_mpis.sh
+++ b/alma/alma-8.x/alma-8.7-hpc/install_mpis.sh
@@ -38,7 +38,8 @@ cp -r ${HPCX_PATH}/ompi/tests ${HPCX_PATH}/hpcx-rebuild
 sed -i "$ s/$/ ucx*/" /etc/dnf/dnf.conf
 
 # Setup module files for MPIs
-mkdir -p /usr/share/Modules/modulefiles/mpi/
+MODULE_FILES_DIRECTORY=/usr/share/modules/modulefiles/mpi
+mkdir -p ${MODULE_FILES_DIRECTORY}
 
 # HPC-X
 cat << EOF >> ${MODULE_FILES_DIRECTORY}/hpcx-${HPCX_VERSION}


### PR DESCRIPTION
The module files directory wasn't defined when referenced during MPI installation