### PR TITLE
Revert CUDA version to 12.2 

### DIFF
--- a/requirements.json
+++ b/requirements.json
@@ -136,29 +136,29 @@
     "cuda": {
         "ubuntu20.04": {
             "driver": {
-                "version": "12-4",
+                "version": "12-2",
                 "distribution": "ubuntu2004"
             },
             "samples": {
-                "version": "12.4"
+                "version": "12.2"
             }   
         },
         "ubuntu22.04": {
             "driver": {
-                "version": "12-4",
+                "version": "12-2",
                 "distribution": "ubuntu2204"
             },
             "samples": {
-                "version": "12.4"
+                "version": "12.2"
             }   
         },
         "almalinux8.7": {
             "driver": {
-                "version": "12-4",
+                "version": "12-2",
                 "distribution": "rhel8"
             },
             "samples": {
-                "version": "12.4"
+                "version": "12.2"
             }   
         }
     },


### PR DESCRIPTION
Revert CUDA version to match driver version (12.2). This was missed in the original revert here: https://github.com/Azure/azhpc-images/pull/334

Closes: #343 