### PR TITLE
cleanup hello-world docker image

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -254,6 +254,7 @@ then
     sudo docker run hello-world
     check_exit_code "Docker installed and working correctly!" "Problem with Docker!"
     sudo docker rm $(sudo docker ps -aq)
+    sudo docker rmi hello-world
 fi
 
 # verify mpi installations and their modulefiles


### PR DESCRIPTION
'hello-world' container image which is left over from docker testing can be flagged by security scanner. it is not needed in the image and should be removed