### PR TITLE
Update SKU Customizations for NCv4

### DIFF
--- a/common/setup_sku_customizations.sh
+++ b/common/setup_sku_customizations.sh
@@ -19,7 +19,7 @@ vmSize=\$(echo "\$vmSize" | awk '{print tolower(\$0)}')
 
 ## Topo file setup based on SKU
 case \$vmSize in
-    standard_nc*ads_a100_v4)
+    standard_nc96ads_a100_v4)
         /opt/azurehpc/customizations/ncv4.sh;;
     
     standard_nd*v4)


### PR DESCRIPTION
NCv4 topo file and graph file is applicable only for the NCv4 96-core VM size. Smaller sizes dont need topo/graph file.