### PR TITLE
delete ssh authorized keys

### DIFF
--- a/common/clear_history.sh
+++ b/common/clear_history.sh
@@ -59,6 +59,7 @@ rm -rf /var/lib/systemd/random-seed
 rm -rf /var/intel/ /var/cache/* /var/lib/cloud/instances/*
 rm -rf /var/lib/hyperv/.kvp_pool_0
 rm -f /etc/ssh/ssh_host_* /etc/*-
+rm -f ~/.ssh/authorized_keys
 rm -rf /tmp/ssh-* /tmp/yum* /tmp/tmp* /tmp/*.log* /tmp/*tenant* /tmp/*.gz
 rm -rf /tmp/nvidia* /tmp/MLNX* /tmp/ofed.conf /tmp/dkms* /tmp/*mlnx*
 rm -rf /run/cloud-init


### PR DESCRIPTION
delete the ssh authorized keys in the cleanup script run before generalizing the VM