### PR TITLE
FM-test

### DIFF
--- a/common/setup_sku_customizations.sh
+++ b/common/setup_sku_customizations.sh
@@ -91,6 +91,13 @@ StandardOutput=journal
 WantedBy=multi-user.target
 EOF
 
+# A workaround to make fabricmanager service start automatically
+FMSYSPATH="/lib/systemd/system/nvidia-fabricmanager.service"
+if [ -f "$FMSYSPATH" ]; then
+    sed -i '/^After=multi-user.target/d' $FMSYSPATH
+    echo "Removed multi-user.target in Unit section"
+fi
+
 systemctl enable sku-customizations
 systemctl start sku-customizations
 systemctl is-active --quiet sku-customizations

--- a/requirements.json
+++ b/requirements.json
@@ -98,38 +98,38 @@
     "nvidia": {
         "ubuntu20.04": {
             "driver": {
-                "version": "535.161.08",
-                "sha256": "0f026c2e6161c0bd453830903c55569e402eb1cf0c5a8e56c39e7998df55565c"
+                "version": "550.54.15",
+                "sha256": "2e859ae5f912a9a47aaa9b2d40a94a14f6f486b5d3b67c0ddf8b72c1c9650385"
             },
             "fabricmanager": {
-                "prefix": "535",
+                "prefix": "550",
                 "distribution": "ubuntu2004",
-                "version": "535_535.161.08-1",
-                "sha256": "7e2e334896f4bd4e5554e2387d11ea8979eef7ee7af7c03370984dcee5a1bfaf"        
+                "version": "550_550.54.15-1",
+                "sha256": "bc4c77ba0e0e88201afe1e44ee673ae55377a55c2f31e5c722d56646454b50ef"        
             }   
         },
         "ubuntu22.04": {
             "driver": {
-                "version": "535.161.08",
-                "sha256": "0f026c2e6161c0bd453830903c55569e402eb1cf0c5a8e56c39e7998df55565c"
+                "version": "550.54.15",
+                "sha256": "2e859ae5f912a9a47aaa9b2d40a94a14f6f486b5d3b67c0ddf8b72c1c9650385"
             },
             "fabricmanager": {
-                "prefix": "535",
+                "prefix": "550",
                 "distribution": "ubuntu2204",
-                "version": "535_535.161.08-1",
-                "sha256": "7e2e334896f4bd4e5554e2387d11ea8979eef7ee7af7c03370984dcee5a1bfaf"        
+                "version": "550_550.54.15-1",
+                "sha256": "bc4c77ba0e0e88201afe1e44ee673ae55377a55c2f31e5c722d56646454b50ef"        
             }   
         },
         "almalinux8.7": {
             "driver": {
-                "version": "535.161.08",
-                "sha256": "0f026c2e6161c0bd453830903c55569e402eb1cf0c5a8e56c39e7998df55565c"
+                "version": "550.54.15",
+                "sha256": "2e859ae5f912a9a47aaa9b2d40a94a14f6f486b5d3b67c0ddf8b72c1c9650385"
             },
             "fabricmanager": {
-                "prefix": "535",
+                "prefix": "550",
                 "distribution": "rhel8",
-                "version": "535.161.08-1",
-                "sha256": "4a21cce2178d7e3555d3880ed4735855d059fbf9c8682ac1435a5c4ab3651ec0"        
+                "version": "550.54.15-1",
+                "sha256": "a617d5f4f93f9f04698af41b261dee2e1280f9802a5ecb8c0a0de0b5c113a343"        
             }   
         }
     },

--- a/requirements.json
+++ b/requirements.json
@@ -98,38 +98,38 @@
     "nvidia": {
         "ubuntu20.04": {
             "driver": {
-                "version": "550.54.15",
-                "sha256": "2e859ae5f912a9a47aaa9b2d40a94a14f6f486b5d3b67c0ddf8b72c1c9650385"
+                "version": "550.90.07",
+                "sha256": "51acf579d5a9884f573a1d3f522e7fafa5e7841e22a9cec0b4bbeae31b0b9733"
             },
             "fabricmanager": {
                 "prefix": "550",
                 "distribution": "ubuntu2004",
-                "version": "550_550.54.15-1",
-                "sha256": "bc4c77ba0e0e88201afe1e44ee673ae55377a55c2f31e5c722d56646454b50ef"        
+                "version": "550_550.90.07-1",
+                "sha256": "f8321f47875fa79968cda38c77c1723ff9fa3ca010f250f17b0075d84f443058"        
             }   
         },
         "ubuntu22.04": {
             "driver": {
-                "version": "550.54.15",
-                "sha256": "2e859ae5f912a9a47aaa9b2d40a94a14f6f486b5d3b67c0ddf8b72c1c9650385"
+                "version": "550.90.07",
+                "sha256": "51acf579d5a9884f573a1d3f522e7fafa5e7841e22a9cec0b4bbeae31b0b9733"
             },
             "fabricmanager": {
                 "prefix": "550",
                 "distribution": "ubuntu2204",
-                "version": "550_550.54.15-1",
-                "sha256": "bc4c77ba0e0e88201afe1e44ee673ae55377a55c2f31e5c722d56646454b50ef"        
+                "version": "550_550.90.07-1",
+                "sha256": "f8321f47875fa79968cda38c77c1723ff9fa3ca010f250f17b0075d84f443058"        
             }   
         },
         "almalinux8.7": {
             "driver": {
-                "version": "550.54.15",
-                "sha256": "2e859ae5f912a9a47aaa9b2d40a94a14f6f486b5d3b67c0ddf8b72c1c9650385"
+                "version": "550.90.07",
+                "sha256": "51acf579d5a9884f573a1d3f522e7fafa5e7841e22a9cec0b4bbeae31b0b9733"
             },
             "fabricmanager": {
                 "prefix": "550",
                 "distribution": "rhel8",
-                "version": "550.54.15-1",
-                "sha256": "a617d5f4f93f9f04698af41b261dee2e1280f9802a5ecb8c0a0de0b5c113a343"        
+                "version": "550.90.07-1",
+                "sha256": "e580c8b412de7a9f352c2eacce877b4cbccd494bfdee7a0e6c94010a06c91c92"        
             }   
         }
     },


### PR DESCRIPTION
This PR adds a workaround to make FM service start automatically on top of branch matt/liquidpt/fm-test.
This is ONLY to share the workaround with team