### PR TITLE
Add ifconfig check to tests

### DIFF
--- a/tests/test-definitions.sh
+++ b/tests/test-definitions.sh
@@ -43,7 +43,7 @@ function verify_ib_device_status {
     check_exit_code "IB device state: LinkUp" "IB link not up"
 
     # verify ifconfig
-    ifconfig | grep "ib0:"
+    ifconfig | grep "ibP"
     check_exit_code "IB device is configured" "IB device not configured"
 }
 

--- a/tests/test-definitions.sh
+++ b/tests/test-definitions.sh
@@ -43,14 +43,8 @@ function verify_ib_device_status {
     check_exit_code "IB device state: LinkUp" "IB link not up"
 
     # verify ifconfig
-    ifconfig | grep "ib0:"
-    if [ $exit_code -eq 0 ]
-    then
-        echo "[OK] : IB device is configured after reboot"
-    else
-        ifconfig | grep "ibP"
-        check_exit_code "IB device is configured before reboot" "IB device not configured"
-    fi
+    ifconfig | grep "ib0:\|ibP"
+    check_exit_code "IB device is configured" "IB device not configured"
 }
 
 function verify_hpcx_installation {

--- a/tests/test-definitions.sh
+++ b/tests/test-definitions.sh
@@ -43,8 +43,14 @@ function verify_ib_device_status {
     check_exit_code "IB device state: LinkUp" "IB link not up"
 
     # verify ifconfig
-    ifconfig | grep "ibP"
-    check_exit_code "IB device is configured" "IB device not configured"
+    ifconfig | grep "ib0:"
+    if [ $exit_code -eq 0 ]
+    then
+        echo "[OK] : IB device is configured after reboot"
+    else
+        ifconfig | grep "ibP"
+        check_exit_code "IB device is configured before reboot" "IB device not configured"
+    fi
 }
 
 function verify_hpcx_installation {

--- a/tests/test-definitions.sh
+++ b/tests/test-definitions.sh
@@ -41,6 +41,10 @@ function verify_ib_device_status {
     # verify IB device is up
     ibstatus | grep "LinkUp"
     check_exit_code "IB device state: LinkUp" "IB link not up"
+
+    # verify ifconfig
+    ifconfig | grep "ib0:"
+    check_exit_code "IB device is configured" "IB device not configured"
 }
 
 function verify_hpcx_installation {


### PR DESCRIPTION
We've run into cases where ibstat shows the infiniband devices, but ifconfig does not. Since this is a bad configuration and will cause issues, we should test ifconfig as well