### PR TITLE
rollback mvapich2

### DIFF
--- a/alma/common/install_mpis.sh
+++ b/alma/common/install_mpis.sh
@@ -45,7 +45,7 @@ sed -i "$ s/$/ ucx*/" /etc/dnf/dnf.conf
 mvapich2_metadata=$(get_component_config "mvapich2")
 MVAPICH2_VERSION=$(jq -r '.version' <<< $mvapich2_metadata)
 MVAPICH2_SHA256=$(jq -r '.sha256' <<< $mvapich2_metadata)
-MVAPICH2_DOWNLOAD_URL="https://mvapich.cse.ohio-state.edu/download/mvapich/mv2/private/mvapich2-2.3.x.tar.gz"
+MVAPICH2_DOWNLOAD_URL="http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-${MVAPICH2_VERSION}.tar.gz"
 TARBALL=$(basename $MVAPICH2_DOWNLOAD_URL)
 MVAPICH2_FOLDER=$(basename $MVAPICH2_DOWNLOAD_URL .tar.gz)
 

--- a/ubuntu/common/install_mpis.sh
+++ b/ubuntu/common/install_mpis.sh
@@ -39,7 +39,7 @@ cp -r ${HPCX_PATH}/ompi/tests ${HPCX_PATH}/hpcx-rebuild
 mvapich2_metadata=$(get_component_config "mvapich2")
 MVAPICH2_VERSION=$(jq -r '.version' <<< $mvapich2_metadata)
 MVAPICH2_SHA256=$(jq -r '.sha256' <<< $mvapich2_metadata)
-MVAPICH2_DOWNLOAD_URL="https://mvapich.cse.ohio-state.edu/download/mvapich/mv2/private/mvapich2-2.3.x.tar.gz"
+MVAPICH2_DOWNLOAD_URL="http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-${MVAPICH2_VERSION}.tar.gz"
 TARBALL=$(basename $MVAPICH2_DOWNLOAD_URL)
 MVAPICH2_FOLDER=$(basename $MVAPICH2_DOWNLOAD_URL .tar.gz)
 

--- a/versions.json
+++ b/versions.json
@@ -42,8 +42,8 @@
     },
     "mvapich2": {
         "common": {
-            "version": "2.3.7-azure",
-            "sha256": "983ac2c4a82eca7681a6caff6d8e6fd39369622453b3b0837c0bce600240d2f7"
+            "version": "2.3.7-1",
+            "sha256": "fdd971cf36d6476d007b5d63d19414546ca8a2937b66886f24a1d9ca154634e4"
         }
     },
     "ompi": {


### PR DESCRIPTION
The new azure tuned MVAPICH2 library was hanging on allreduce or alltoall. Rollback to the previous version.