### PR TITLE
Enable full Ubuntu 22.04 configuration for AMD MI300x

### DIFF
--- a/ubuntu/ubuntu-22.x/ubuntu-22.04-hpc/install.sh
+++ b/ubuntu/ubuntu-22.x/ubuntu-22.04-hpc/install.sh
@@ -7,14 +7,12 @@ if [[ "$#" -gt 0 ]]; then
     INPUT=$1
     if [ "$INPUT" == "AMD" ]; then
         GPUi="AMD"
-	echo "ERROR, the AMD pathway is not fully implemented yet."
-	exit 1
+	echo "Configuring VM for AMD GPUs."
     elif [ "$INPUT" != "NVIDIA" ]; then
         echo "Error: Invalid GPU type. Please specify 'NVIDIA' or 'AMD'."
 	exit 1
     fi
 fi
-
 
 export GPU=$GPUi
 

--- a/ubuntu/ubuntu-22.x/ubuntu-22.04-hpc/install_rccl.sh
+++ b/ubuntu/ubuntu-22.x/ubuntu-22.04-hpc/install_rccl.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 set -ex
 
+pushd /tmp
+wget https://github.com/Kitware/CMake/releases/download/v3.30.5/cmake-3.30.5-linux-x86_64.tar.gz
+tar xzf cmake-3.30.5-linux-x86_64.tar.gz
+pushd cmake-3.30.5-linux-x86_64
+pushd bin
+sudo mv -f ccmake cmake cpack ctest /usr/local/bin
+popd
+sudo cp -r share/cmake-3.30 /usr/local/share/
+popd
+rm -rf cmake-3.30.5-linux-x86_64*
+popd
+
 apt install libstdc++-12-dev
 apt remove -y rccl
 pushd ~

--- a/ubuntu/ubuntu-22.x/ubuntu-22.04-hpc/install_rocm.sh
+++ b/ubuntu/ubuntu-22.x/ubuntu-22.04-hpc/install_rocm.sh
@@ -16,8 +16,7 @@ usermod -a -G video $(logname)
 
 #add future new users to the render and video groups.
 echo 'ADD_EXTRA_GROUPS=1' | tee -a /etc/adduser.conf
-echo 'EXTRA_GROUPS=video' | tee -a /etc/adduser.conf
-echo 'EXTRA_GROUPS=render' | tee -a /etc/adduser.conf
+echo 'EXTRA_GROUPS="video render"' | tee -a /etc/adduser.conf
 
 #add nofile limits
 string_so="*               soft    nofile          1048576"

--- a/ubuntu/ubuntu-22.x/ubuntu-22.04-hpc/install_rocm.sh
+++ b/ubuntu/ubuntu-22.x/ubuntu-22.04-hpc/install_rocm.sh
@@ -3,7 +3,7 @@ set -ex
 
 pushd /tmp
 wget https://repo.radeon.com/amdgpu-install/latest/ubuntu/jammy/amdgpu-install_6.2.60202-1_all.deb
-sudo apt install ./amdgpu-install_6.2.60202-1_all.deb
+sudo apt install -y ./amdgpu-install_6.2.60202-1_all.deb
 rm -f amdgpu-install_6.2.60202-1_all.deb
 popd
 

--- a/ubuntu/ubuntu-22.x/ubuntu-22.04-hpc/install_rocm.sh
+++ b/ubuntu/ubuntu-22.x/ubuntu-22.04-hpc/install_rocm.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 set -ex
 
-#move to rocm package
-./amdgpu-install -y --usecase=graphics,rocm
+pushd /tmp
+wget https://repo.radeon.com/amdgpu-install/latest/ubuntu/jammy/amdgpu-install_6.2.60202-1_all.deb
+sudo apt install ./amdgpu-install_6.2.60202-1_all.deb
+rm -f amdgpu-install_6.2.60202-1_all.deb
+popd
 
+#move to rocm package
+amdgpu-install -y --usecase=graphics,rocm
 
 #Add self to render and video groups so they can access gpus.
 usermod -a -G render $(logname)

--- a/ubuntu/ubuntu-22.x/ubuntu-22.04-hpc/install_rocm.sh
+++ b/ubuntu/ubuntu-22.x/ubuntu-22.04-hpc/install_rocm.sh
@@ -2,9 +2,9 @@
 set -ex
 
 pushd /tmp
-wget https://repo.radeon.com/amdgpu-install/latest/ubuntu/jammy/amdgpu-install_6.2.60202-1_all.deb
-sudo apt install -y ./amdgpu-install_6.2.60202-1_all.deb
-rm -f amdgpu-install_6.2.60202-1_all.deb
+wget https://repo.radeon.com/amdgpu-install/latest/ubuntu/jammy/amdgpu-install_6.3.60300-1_all.deb
+sudo apt install -y ./amdgpu-install_6.3.60300-1_all.deb
+rm -f amdgpu-install_6.3.60300-1_all.deb
 popd
 
 #move to rocm package

--- a/ubuntu/ubuntu-22.x/ubuntu-22.04-hpc/install_rocm.sh
+++ b/ubuntu/ubuntu-22.x/ubuntu-22.04-hpc/install_rocm.sh
@@ -2,9 +2,9 @@
 set -ex
 
 pushd /tmp
-wget https://repo.radeon.com/amdgpu-install/latest/ubuntu/jammy/amdgpu-install_6.3.60300-1_all.deb
-sudo apt install -y ./amdgpu-install_6.3.60300-1_all.deb
-rm -f amdgpu-install_6.3.60300-1_all.deb
+wget https://repo.radeon.com/amdgpu-install/6.2.2/ubuntu/jammy/amdgpu-install_6.2.60202-1_all.deb
+sudo apt install -y ./amdgpu-install_6.2.60202-1_all.deb
+rm -f amdgpu-install_6.2.60202-1_all.deb
 popd
 
 #move to rocm package


### PR DESCRIPTION
This PR introduces the following changes:

- Enables the use of the `AMD` flag to configure ROCm drivers and associated installations
- Automatically downloads and installs `amdgpu_install` utility
- Installs Cmake 3.30.5 required by RCCL
- Fixes the default assignment of user secondary groups `video` and `render`