### PR TITLE
updating url for azcopy download

### DIFF
--- a/common/install_azcopy.sh
+++ b/common/install_azcopy.sh
@@ -9,7 +9,7 @@ azcopy_version=$(jq -r '.version' <<< $azcopy_metadata)
 azcopy_release=$(jq -r '.release' <<< $azcopy_metadata)
 azcopy_sha256=$(jq -r '.sha256' <<< $azcopy_metadata)
 TARBALL="azcopy_linux_amd64_$azcopy_version.tar.gz"
-AZCOPY_DOWNLOAD_URL="https://azcopyvnext.azureedge.net/releases/release-${azcopy_release}/${TARBALL}"
+AZCOPY_DOWNLOAD_URL="https://azcopyvnext-awgzd8g7aagqhzhe.b02.azurefd.net/releases/release-${azcopy_release}/${TARBALL}"
 
 ${COMMON_DIR}/download_and_verify.sh ${AZCOPY_DOWNLOAD_URL} ${azcopy_sha256}
 tar -xvf ${TARBALL}


### PR DESCRIPTION
The url to download azcopy in this repository no longer works. I have updated the URL so the install of azcopy is successful. 