### PR TITLE
Add NCCL_IGNORE_CPU_AFFINITY flag to nccl conf. Remove useless code

### DIFF
--- a/common/setup_sku_customizations.sh
+++ b/common/setup_sku_customizations.sh
@@ -51,9 +51,6 @@ case \$vmSize in
     standard_nd96is*_h[1-2]00_v5)
         /opt/azurehpc/customizations/ndv5.sh;;
 
-    standard_nd96is*_mi300x_v5)
-        /opt/azurehpc/customizations/ndv5.sh;;
-
     *) echo "No SKU customization for \$vmSize";;
 esac
 EOF
@@ -98,20 +95,9 @@ vmSize=\$(echo "\$vmSize" | awk '{print tolower(\$0)}')
 
 ## Topo file setup based on SKU
 case \$vmSize in
-    standard_nc96ads_a100_v4)
-        /opt/azurehpc/customizations/ncv4.sh;;
     
     standard_nd*v4)
         /opt/azurehpc/customizations/ndv4_rocm.sh;;
-        
-    standard_nd40rs_v2)
-        /opt/azurehpc/customizations/ndv2.sh;;
-
-    standard_hb176*v4)
-        /opt/azurehpc/customizations/hbv4.sh;;
-
-    standard_nd96is*_h100_v5)
-        /opt/azurehpc/customizations/ndv5_rocm.sh;;
 
     standard_nd96is*_mi300x_v5)
         /opt/azurehpc/customizations/ndv5_rocm.sh;;

--- a/customizations/ncv4.sh
+++ b/customizations/ncv4.sh
@@ -12,6 +12,7 @@ ln -sf /opt/microsoft/ncv4-graph.xml /opt/microsoft/ncv4/graph.xml
 bash -c "cat > /etc/nccl.conf" <<'EOF'
 NCCL_TOPO_FILE=/opt/microsoft/ncv4/topo.xml
 NCCL_GRAPH_FILE=/opt/microsoft/ncv4/graph.xml
+NCCL_IGNORE_CPU_AFFINITY=1
 EOF
 
 ## Setup NVME devices

--- a/customizations/ndv2.sh
+++ b/customizations/ndv2.sh
@@ -10,4 +10,5 @@ ln -sf /opt/microsoft/ndv2-topo.xml /opt/microsoft/ndv2/topo.xml
 ## Set NCCL configuration file for NDv2
 bash -c "cat > /etc/nccl.conf" <<'EOF'
 NCCL_TOPO_FILE=/opt/microsoft/ndv2/topo.xml
+NCCL_IGNORE_CPU_AFFINITY=1
 EOF

--- a/customizations/ndv4.sh
+++ b/customizations/ndv4.sh
@@ -11,6 +11,7 @@ ln -sf /opt/microsoft/ndv4-topo.xml /opt/microsoft/ndv4/topo.xml
 bash -c "cat > /etc/nccl.conf" <<'EOF'
 NCCL_IB_PCI_RELAXED_ORDERING=1
 NCCL_TOPO_FILE=/opt/microsoft/ndv4/topo.xml
+NCCL_IGNORE_CPU_AFFINITY=1
 EOF
 
 ## NVIDIA Fabric manager

--- a/customizations/ndv4_rocm.sh
+++ b/customizations/ndv4_rocm.sh
@@ -1,15 +1,4 @@
 #!/bin/bash
 set -ex
 
-# Place NDv4 topo file under /opt/microsoft/ndv4
-mkdir -p /opt/microsoft/ndv4
-
-# Link the NDv4 topology file into /opt/microsoft/ndv4/
-ln -sf /opt/microsoft/ndv4-topo.xml /opt/microsoft/ndv4/topo.xml
-
-## Set NCCL configuration file for NDv4
-bash -c "cat > /etc/nccl.conf" <<'EOF'
-NCCL_IB_PCI_RELAXED_ORDERING=1
-NCCL_TOPO_FILE=/opt/microsoft/ndv4/topo.xml
-EOF
-
+# Place holder for future ROCM SKU customization

--- a/customizations/ndv5.sh
+++ b/customizations/ndv5.sh
@@ -11,6 +11,7 @@ ln -sf /opt/microsoft/ndv5-topo.xml /opt/microsoft/ndv5/topo.xml
 bash -c "cat > /etc/nccl.conf" <<'EOF'
 NCCL_IB_PCI_RELAXED_ORDERING=1
 NCCL_TOPO_FILE=/opt/microsoft/ndv5/topo.xml
+NCCL_IGNORE_CPU_AFFINITY=1
 EOF
 
 ## NVIDIA Fabric manager

--- a/customizations/ndv5_rocm.sh
+++ b/customizations/ndv5_rocm.sh
@@ -1,15 +1,4 @@
 #!/bin/bash
 set -ex
 
-# Place NDv5 customizations under /opt/microsoft/ndv5
-mkdir -p /opt/microsoft/ndv5
-
-# Link the NDv5 topology file into /opt/microsoft/ndv5/
-ln -sf /opt/microsoft/ndv5-topo.xml /opt/microsoft/ndv5/topo.xml
-
-## Set NCCL configuration file for NDv5
-bash -c "cat > /etc/nccl.conf" <<'EOF'
-NCCL_IB_PCI_RELAXED_ORDERING=1
-NCCL_TOPO_FILE=/opt/microsoft/ndv5/topo.xml
-EOF
-
+# Place holder for future ROCM SKU customization


### PR DESCRIPTION
- Modify ND and NCv4 sku customization scripts to add "NCCL_IGNORE_CPU_AFFINITY=1" to the nccl.conf file
- Remove unutilized code from the custimization files
- Put NVME disk setop commands as place holders for AMD SKU customization in place of nccl.conf creation