### PR TITLE
Fix render group membership

### DIFF
--- a/tests/test-definitions.sh
+++ b/tests/test-definitions.sh
@@ -184,6 +184,9 @@ function verify_rccl_installation {
 
     module load mpi/hpcx
 
+    amdgpumod=$(lsmod | grep "^amdgpu")
+    check_exit_code "amdgpu driver is loaded" "No amdgpu driver"
+    
     case ${VMSIZE} in
         standard_nd96isr_mi300x_v5) mpirun -np 8 \
             --allow-run-as-root \

--- a/ubuntu/ubuntu-22.x/ubuntu-22.04-hpc/install_rocm.sh
+++ b/ubuntu/ubuntu-22.x/ubuntu-22.04-hpc/install_rocm.sh
@@ -17,14 +17,16 @@ apt install -y rocm-bandwidth-test
 rm -f ./${DEBPACKAGE}
 $COMMON_DIR/write_component_version.sh "ROCM" ${rocm_version}
 
+#Update cloud.cfg to add the first user to the render group
+sed -i 's/groups: \[.*/groups: \[render, adm, audio, cdrom, dialout, dip, floppy, lxd, netdev, plugdev, sudo, video\]/' /etc/cloud/cloud.cfg
+
 #Add self to render and video groups so they can access gpus.
 usermod -a -G render $(logname)
 usermod -a -G video $(logname)
 
 #add future new users to the render and video groups.
 echo 'ADD_EXTRA_GROUPS=1' | tee -a /etc/adduser.conf
-echo 'EXTRA_GROUPS=video' | tee -a /etc/adduser.conf
-echo 'EXTRA_GROUPS=render' | tee -a /etc/adduser.conf
+echo 'EXTRA_GROUPS="video render"' | tee -a /etc/adduser.conf
 
 #add nofile limits
 string_so="*               soft    nofile          1048576"


### PR DESCRIPTION
The first username created during the VM deployment was not in the render group causing the rccl test not to run