### PR TITLE
Make sanity check continues on error

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -5,6 +5,11 @@
 # Description : This script performs initialization and testing for a specified platform.
 # Usage       : ./example.sh <platform> [debug_flag]
 #
+# Sample Usage:
+#   ./run-tests.sh 
+#   ./example.sh NVIDIA -d
+#   ./example.sh AMD -d
+
 # Arguments   :
 #   $1 - Platform type (optional):
 #        "AMD" or "NVIDIA"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,5 +1,21 @@
 #!/bin/bash
 
+# ------------------------------------------------------------------------------
+# Script Name : example.sh
+# Description : This script performs initialization and testing for a specified platform.
+# Usage       : ./example.sh <platform> [debug_flag]
+#
+# Arguments   :
+#   $1 - Platform type (optional):
+#        "AMD" or "NVIDIA"
+#        "NVIDIA" when omitted
+#
+#   $2 - Debug mode flag (optional):
+#        Specify "-d" to enable debug mode. 
+#        In debug mode, the script continues running even if a single test fails.
+#        If omitted or not "-d", the script runs in normal mode (strict failure handling).
+
+# ------------------------------------------------------------------------------
 function test_service {
     local service=$1
     
@@ -142,6 +158,7 @@ set_sku_configuration
 # Set test matrix
 set_test_matrix $1
 # Initiate test suite
+if [[ -n "$2" && "$2" == "-d" ]]; then export HPC_DEBUG=$2; else export HPC_DEBUG=; fi 
 initiate_test_suite
 
 echo "ALL OK!"

--- a/tests/test-definitions.sh
+++ b/tests/test-definitions.sh
@@ -7,8 +7,8 @@ function check_exists {
     then
         echo "$1 [OK]"
     else
-        echo "*** Error - $1 not found!" >&2
-        exit -1
+        echo "*** ${FUNCNAME[1]} Error - $1 not found!" >&2
+        if ! [[ -n "$HPC_DEBUG" && "$HPC_DEBUG" == "-d" ]]; then exit -1; fi 
     fi
 }
 
@@ -19,9 +19,9 @@ function check_exit_code {
     then
         echo "[OK] : $1"
     else
-        echo "*** Error - $2!" >&2
+        echo "*** ${FUNCNAME[1]}: Error - $2!" >&2
         echo "*** Failed with exit code - $exit_code" >&2
-        exit -1
+        if ! [[ -n "$HPC_DEBUG" && "$HPC_DEBUG" == "-d" ]]; then exit -1; fi 
     fi
 }
 


### PR DESCRIPTION
Adds a flag on run-tests.sh and enables the sanity check continue to run when a single function fails, which can help understand the thorough VM status in local tests. The flag is optional. 