### PR TITLE
refine component version

### DIFF
--- a/azurelinux/common/install_gdrcopy.sh
+++ b/azurelinux/common/install_gdrcopy.sh
@@ -16,8 +16,8 @@ nvidia_driver_metadata=$(get_component_config "nvidia")
 NVIDIA_DRIVER_VERSION=$(jq -r '.driver.version' <<< $nvidia_driver_metadata)
 
 # Install gdrcopy kmod and devel packages from PMC
-tdnf install -y gdrcopy \
-                gdrcopy-kmod-2.5-7_$kernel_version.$NVIDIA_DRIVER_VERSION.azl3.x86_64 \
-                gdrcopy-devel
+tdnf install -y gdrcopy-${GDRCOPY_VERSION}.azl3.x86_64 \
+                gdrcopy-kmod-${GDRCOPY_VERSION}_$kernel_version.$NVIDIA_DRIVER_VERSION.azl3.x86_64 \
+                gdrcopy-devel-${GDRCOPY_VERSION}.azl3.noarch
 
 $COMMON_DIR/write_component_version.sh "GDRCOPY" ${GDRCOPY_VERSION}

--- a/azurelinux/common/install_mellanoxofed.sh
+++ b/azurelinux/common/install_mellanoxofed.sh
@@ -29,6 +29,9 @@ tdnf install -y bison \
 
 mofed_metadata=$(get_component_config "mofed")
 MOFED_VERSION=$(jq -r '.version' <<< $mofed_metadata)
+XPMEM_VERSION=$(jq -r '.xpmem.version' <<< $mofed_metadata)
+KNEM_VERSION=$(jq -r '.knem.version' <<< $mofed_metadata)
+MFT_KERNEL_VERSION=$(jq -r '.mft_kernel.version' <<< $mofed_metadata)
 
 kernel_version=$(uname -r | sed 's/\-/./g')
 
@@ -42,28 +45,28 @@ tdnf install -y libibumad \
                 librdmacm-utils \
                 rdma-core \
                 rdma-core-devel \
-                mlnx-ofa_kernel-24.10-20_$kernel_version.x86_64 \
-                mlnx-ofa_kernel-modules-24.10-20_$kernel_version.x86_64 \
-                mlnx-ofa_kernel-devel-24.10-20_$kernel_version.x86_64 \
-                mlnx-ofa_kernel-source-24.10-20_$kernel_version.x86_64 \
-                mft_kernel-4.30.0-20_$kernel_version.x86_64 \
+                mlnx-ofa_kernel-${MOFED_VERSION}_$kernel_version.x86_64 \
+                mlnx-ofa_kernel-modules-${MOFED_VERSION}_$kernel_version.x86_64 \
+                mlnx-ofa_kernel-devel-${MOFED_VERSION}_$kernel_version.x86_64 \
+                mlnx-ofa_kernel-source-${MOFED_VERSION}_$kernel_version.x86_64 \
+                mft_kernel-${MFT_KERNEL_VERSION}_$kernel_version.x86_64 \
                 mstflint \
-                fwctl-24.10-20_$kernel_version.x86_64 \
+                fwctl-${MOFED_VERSION}_$kernel_version.x86_64 \
                 ibacm \
                 ibarr \
                 ibsim \
-                iser-24.10-20_$kernel_version.x86_64 \
-                isert-24.10-20_$kernel_version.x86_64 \
-                knem-1.1.4.90mlnx3-20_$kernel_version.x86_64 \
-                knem-modules-1.1.4.90mlnx3-20_$kernel_version.x86_64 \
+                iser-${MOFED_VERSION}_$kernel_version.x86_64 \
+                isert-${MOFED_VERSION}_$kernel_version.x86_64 \
+                knem-${KNEM_VERSION}_$kernel_version.x86_64 \
+                knem-modules-${KNEM_VERSION}_$kernel_version.x86_64 \
                 perftest \
-                libxpmem-2.7.4-20_$kernel_version.x86_64 \
-                libxpmem-devel-2.7.4-20_$kernel_version.x86_64 \
+                libxpmem-${XPMEM_VERSION}_$kernel_version.x86_64 \
+                libxpmem-devel-${XPMEM_VERSION}_$kernel_version.x86_64 \
                 mlnx-ethtool \
                 mlnx-iproute2 \
-                mlnx-nfsrdma-24.10-20_$kernel_version.x86_64 \
+                mlnx-nfsrdma-${MOFED_VERSION}_$kernel_version.x86_64 \
                 multiperf \
-                srp-24.10-20_$kernel_version.x86_64 \
+                srp-${MOFED_VERSION}_$kernel_version.x86_64 \
                 srp_daemon \
                 ucx \
                 ucx-cma \
@@ -73,8 +76,8 @@ tdnf install -y libibumad \
                 ucx-rdmacm \
                 ucx-static \
                 ucx-knem \
-                xpmem-2.7.4-20_$kernel_version.x86_64 \
-                xpmem-modules-2.7.4-20_$kernel_version.x86_64 \
+                xpmem-${XPMEM_VERSION}_$kernel_version.x86_64 \
+                xpmem-modules-${XPMEM_VERSION}_$kernel_version.x86_64 \
                 ucx-xpmem \
                 libunwind \
                 libunwind-devel

--- a/azurelinux/common/install_pmix.sh
+++ b/azurelinux/common/install_pmix.sh
@@ -6,7 +6,7 @@ source ${COMMON_DIR}/utilities.sh
 pmix_metadata=$(get_component_config "pmix")
 PMIX_VERSION=$(jq -r '.version' <<< $pmix_metadata)
 
-tdnf -y install pmix pmix-devel pmix-tools
+tdnf -y install pmix-${PMIX_VERSION}.azl3.x86_64 pmix-devel-${PMIX_VERSION}.azl3.x86_64 pmix-tools-${PMIX_VERSION}.azl3.x86_64
 tdnf -y install hwloc-devel libevent-devel munge-devel
 
 $COMMON_DIR/write_component_version.sh "PMIX" ${PMIX_VERSION}

--- a/versions.json
+++ b/versions.json
@@ -84,7 +84,10 @@
     },
     "mofed": {
         "azurelinux3.0": {
-            "version": "24.10.0.7.0",
+            "version": "24.10-20",
+            "xpmem.version": "2.7.4-20",
+            "knem.version": "1.1.4.90mlnx3-20",
+            "mft_kernel.version": "4.30.0-20",
             "sha256": "34e826fea03d6505b50909959ed029282a6238c75830fbe5b2bc15442cf8f8b5"
         }
     },
@@ -269,7 +272,7 @@
             "distribution": "el8"
         },
         "azurelinux3.0": {
-            "version": "2.5",
+            "version": "2.5-7",
             "sha256": "9f1ddefaf7ebf09f1f4cb04873ed9fb255ddfd819ab1cf5ec2e73ed96140565a",
             "distribution": "azl3"
         }


### PR DESCRIPTION
1. Remove hard-coded versions in the script: Specify PMIx, GDRCopy, and OFED versions in versions.json, and consume these values during installation.
2. Use more precise version numbers: Update GDRCopy from 2.5 → 2.5-7 and OFED from 24.10.0.7.0 → 24.10-20. Note that these versions are functionally identical (the same package versions). Previously, versions were retrieved via tdnf info; the updated ones can be used directly in tdnf install.