### PR TITLE
add systemdcgroup=true on /etc/containerd/config.toml on azurelinux

### DIFF
--- a/azurelinux/common/install_docker.sh
+++ b/azurelinux/common/install_docker.sh
@@ -23,8 +23,9 @@ systemctl restart docker
 # nvidia-docker run -e NVIDIA_VISIBLE_DEVICES=all nvidia/cuda:11.0-base nvidia-smi
 mkdir -p /etc/containerd
 containerd config default | sudo tee /etc/containerd/config.toml
-sed -i 's/SystemdCgroup = false/SystemdCgroup = true/g' /etc/containerd/config.toml  
 nvidia-ctk runtime configure --runtime=containerd
+sed -i '/\[plugins\.\"io\.containerd\.cri\.v1\.runtime\".containerd\.runtimes\.runc\.options\]/a \ \ \ \ \ \ \ \ \ \ \ \ SystemdCgroup = true' /etc/containerd/config.toml
+sed -i '/\[plugins\.\"io\.containerd\.cri\.v1\.runtime\".containerd\.runtimes\.nvidia\.options\]/a \ \ \ \ \ \ \ \ \ \ \ \ SystemdCgroup = true' /etc/containerd/config.toml
 
 # restart containerd service
 systemctl restart containerd


### PR DESCRIPTION
AzureLinux uses containerd 2.x, in which the config toml file is version 3. The default file generated by "containerd config default" does not have SystemdCgroup config 

<img width="2012" height="46" alt="image" src="https://github.com/user-attachments/assets/4b951d27-9975-42af-8697-aa2986138446" />
