### PR TITLE
Fix Alma8.10 DNS resolution

### DIFF
--- a/components/disable_cloudinit.sh
+++ b/components/disable_cloudinit.sh
@@ -45,6 +45,15 @@ RemainAfterExit=yes
 WantedBy=multi-user.target
 EOF
         systemctl daemon-reload
+        systemctl enable disable_cloudinit.service
+        systemctl start disable_cloudinit.service
+        systemctl is-active --quiet disable_cloudinit.service
+        error_code=$?
+        if [ ${error_code} -ne 0 ]
+        then
+            echo "Disable Cloud Init service Inactive!"
+            exit ${error_code}
+        fi
     fi
 else
     echo network: {config: disabled} | sudo tee /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg


### PR DESCRIPTION
On Alma8.10, Cloud init keeps reverting the changes /etc/sysconfig/network-scripts/ifcfg-eth0 even though it is disabled. Thus adding a disable cloudinit service to fix the issue.