### PR TITLE
Refresh Ubuntu 24.04 V100/A100+ Images for CUDA compatibility issues

### DIFF
--- a/utils/utilities.sh
+++ b/utils/utilities.sh
@@ -6,23 +6,13 @@
 ############################################################################
 get_component_config(){
     component=$1
-    gpu_and_sku=${GPU,,}-${SKU,,}
   
     config=$(jq -r '."'"${component}"'"."'"${DISTRIBUTION}"'"' <<< "${COMPONENT_VERSIONS}")
     if [[ "$config" = "null" ]]; then
         config=$(jq -r '."'"${component}"'".common' <<< "${COMPONENT_VERSIONS}")
     fi
-
-    nested_gpu_config=$(jq -r '."'"${gpu_and_sku}"'"' <<< "${config}")
-    if [[ "$nested_gpu_config" = "null" ]]; then
-        nested_gpu_config=$(jq -r '.common' <<< "${config}")
-    fi
-
-    if [[ "$nested_gpu_config" != "null" ]]; then
-        echo "$nested_gpu_config"
-    else
-        echo "$config"
-    fi
+    
+    echo "$config"
 }
 
 ############################################################################

--- a/versions.json
+++ b/versions.json
@@ -46,8 +46,8 @@
     "hpcx": {
         "ubuntu22.04": {
             "version": "2.24.1",
-            "sha256": "6a999297fda98ca833c47a09a6a13e92d4f759d75a9258ec2355304d479e4653",
-            "url": "https://content.mellanox.com/hpc/hpc-x/v2.24.1_cuda12/hpcx-v2.24.1-gcc-doca_ofed-ubuntu22.04-cuda12-x86_64.tbz"
+            "sha256": "622be4b7fc739e42a70578fdc72784bfa8aac3c6a66e89d67142bdbf5227a7eb",
+            "url": "https://content.mellanox.com/hpc/hpc-x/v2.24.1_cuda13/hpcx-v2.24.1-gcc-doca_ofed-ubuntu22.04-cuda13-x86_64.tbz"
         },
         "ubuntu24.04": {
             "version": "2.24.1",
@@ -114,9 +114,9 @@
             "url": "http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3.7-2.tar.gz"
         },
         "almalinux9.6": {
-            "version": "4.1",
-            "sha256": "25a53d3725b669e2c648158fb7c9fc5b1388953f3a2f949748586c447d0e43ee",
-            "url": "https://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich-4.1.tar.gz"
+            "version": "4.0",
+            "sha256": "c532f7bdd5cca71f78c12e0885c492f6e276e283711806c84d0b0f80bb3e3b74",
+            "url": "https://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich-4.0.tar.gz"
         },
         "azurelinux3.0": {
             "version": "2.3.7-1",
@@ -146,14 +146,14 @@
     "nvidia": {
         "ubuntu22.04": {
             "driver": {
-                "version": "570.195.03",
-                "sha256": "d47de81d9a513496a60adc9cfa72fe9e162c65f2722fb960c4f531bd7ac5dc1e"
+                "version": "580.95.05",
+                "sha256": "849ef0ef8e842b9806b2cde9f11c1303d54f1a9a769467e4e5d961b2fe1182a7"
             },
             "fabricmanager": {
                 "distribution": "ubuntu2204",
-                "version": "570.195.03-1",
-                "sha256": "4cd66890a2cbc7c115072910b45c476754ac3628778e9df9c16bc34585bd356d"
-            }
+                "version": "580.95.05-1",
+                "sha256": "b20e3a2bfa46fb8ae4adf19a265d07e962f03e4306ea3261f6c7e9adc678b442"        
+            }   
         },
         "ubuntu24.04": {
             "driver": {
@@ -179,14 +179,14 @@
         },
         "almalinux9.6": {
             "driver": {
-                "version": "580.95.05",
-                "sha256": "849ef0ef8e842b9806b2cde9f11c1303d54f1a9a769467e4e5d961b2fe1182a7"
+                "version": "570.172.08",
+                "sha256": "0256867e082caf93d7b25fa7c8e69b316062a9c6c72c6e228fad7b238c6fa17d"
             },
             "fabricmanager": {
                 "distribution": "rhel9",
-                "version": "580.95.05-1",
-                "sha256": "36d78cd5f2bacb37c286f7f6949968c48139fcbf76a03fafbe1860666c3e16fb"
-            }
+                "version": "570.172.08-1",
+                "sha256": "6e4e0860adfceff8ec8a9451620219b67ac84bfe2dfc9a77c1cd09e2aa2b7c00"
+            }   
         },
         "rhel8.10": {
             "driver": {
@@ -210,12 +210,12 @@
     "cuda": {
         "ubuntu22.04": {
             "driver": {
-                "version": "12.8",
+                "version": "13.0",
                 "distribution": "ubuntu2204"
             },
             "samples": {
-                "version": "12.8",
-                "sha256": "fe82484f9a87334075498f4e023a304cc70f240a285c11678f720f0a1e54a89d"
+                "version": "13.0",
+                "sha256": "63cc9d5d8280c87df3c1f4e2276234a0f42cc497c52b40dd5bdda2836607db79"
             }
         },
         "ubuntu24.04": {


### PR DESCRIPTION
The [Ubuntu 24.04 HPC Image - 20250930](https://github.com/Azure/azhpc-images/releases/tag/ubuntu-hpc-20250930) and [Ubuntu 24.04 HPC V100 - 20251009](https://github.com/Azure/azhpc-images/releases/tag/ubuntu-hpc-20251009) image releases faced a compatibility issue where libcuda installed with the Nvidia drivers was not new enough for the CUDA toolkit version. https://github.com/Azure/azhpc-images/pull/449 fixed the compatibility check, and this PR updates the Nvidia drivers and downgrades the CUDA toolkit version to make a compatible match.