### PR TITLE
skip the apt upgrade if calling from the GB200 installer in AzS

### DIFF
--- a/utils/set_properties.sh
+++ b/utils/set_properties.sh
@@ -22,8 +22,15 @@ if [[ $DISTRIBUTION == *"ubuntu"* ]]; then
     #    apt-mark hold linux-azure
     # fi
     # upgrade pre-installed components
-    apt update
-    apt upgrade -y
+    # GB200 offline installer: Skip apt upgrade when running from offline ISO.
+    # The upgrade pulls packages from online mirrors that may be unavailable,
+    # causing the install to fail. The base image is already validated.
+    if [[ "${GB200_SKIP_APT_UPGRADE:-0}" != "1" ]]; then
+        apt update
+        apt upgrade -y
+    else
+        echo "[set_properties.sh] Skipping apt update/upgrade (GB200_SKIP_APT_UPGRADE=1)"
+    fi
     # jq is needed to parse the component versions from the versions.json file
     apt install -y jq
     export MODULE_FILES_DIRECTORY=/usr/share/modules/modulefiles


### PR DESCRIPTION
## Summary
Skip apt update/upgrade when running from GB200 offline installer

## Problem
When the GB200 offline installer sources `set_properties.sh`, the `apt upgrade -y` 
command tries to fetch packages from online mirrors. In offline/air-gapped 
environments, this fails with "Network is unreachable" errors, causing the 
installation to abort.

## Solution
Check for `GB200_SKIP_APT_UPGRADE=1` environment variable before running 
apt update/upgrade. The GB200 offline installer sets this flag since the 
base image is already validated and contains all required packages.

## Testing
- Tested with GB200 offline ISO installer in air-gapped environment
- Standard online installation path remains unchanged (flag not set by default)