### PR TITLE
Ubuntu 24.04 V100 March 26 refresh

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -107,9 +107,9 @@
             },
             "x86_64": {
                 "nvidia_v100": {
-                    "version": "2.26",
-                    "sha256": "55fc0b15041e1f7007c10aea2c3e5a42979e7c15682d050da5dcc5b21846e84e",
-                    "url": "https://content.mellanox.com/hpc/hpc-x/v2.26_cuda12/hpcx-v2.26-gcc-doca_ofed-ubuntu24.04-cuda12-x86_64.tbz"
+                    "version": "2.25.1",
+                    "sha256": "12dced766fee0946210693ab7ee8b7a7491082a775db837bcfd73323f155e4a7",
+                    "url": "https://content.mellanox.com/hpc/hpc-x/v2.25.1_cuda12/hpcx-v2.25.1-gcc-doca_ofed-ubuntu24.04-cuda12-x86_64.tbz"
                 },
                 "version": "2.25.1",
                 "sha256": "8767bea4f0967a6b0f5e1b31395a431bf5624eaf34c928f109bc2db985f26887",

--- a/versions.json
+++ b/versions.json
@@ -28,9 +28,9 @@
         },
         "ubuntu24.04": {
             "x86_64": {
-                "version": "3.3.0",
-                "sha256": "2310b597cb2bb1b70c8db1b0641ac531ee4d5051c5d86299f1f3d7dbf3475ad5",
-                "url": "https://www.mellanox.com/downloads/DOCA/DOCA_v3.3.0/host/doca-host_3.3.0-088000-26.01-ubuntu2204_amd64.deb"
+                "version": "3.2.1",
+                "sha256": "f16f08572b3b2f513b80af66c881c6a60c19e74f0da50afafaa42b0c34116533",
+                "url": "https://www.mellanox.com/downloads/DOCA/DOCA_v3.2.1/host/doca-host_3.2.1-044000-25.10-ubuntu2404_amd64.deb"
             },
             "aarch64": {
                 "version": "3.2.1",

--- a/versions.json
+++ b/versions.json
@@ -21,11 +21,6 @@
     "doca": {
         "ubuntu22.04": {
             "x86_64": {
-                "nvidia_v100": {
-                    "version": "3.3.0",
-                    "sha256": "2310b597cb2bb1b70c8db1b0641ac531ee4d5051c5d86299f1f3d7dbf3475ad5",
-                    "url": "https://www.mellanox.com/downloads/DOCA/DOCA_v3.3.0/host/doca-host_3.3.0-088000-26.01-ubuntu2204_amd64.deb"
-                },
                 "version": "3.2.1",
                 "sha256": "75b8d4258b7239ef5021abaa25e7eeb4fcbc0c8117cab89ce1a766d2d218c8a0",
                 "url": "https://www.mellanox.com/downloads/DOCA/DOCA_v3.2.1/host/doca-host_3.2.1-044000-25.10-ubuntu2204_amd64.deb"
@@ -33,6 +28,11 @@
         },
         "ubuntu24.04": {
             "x86_64": {
+                "nvidia_v100": {
+                    "version": "3.3.0",
+                    "sha256": "2310b597cb2bb1b70c8db1b0641ac531ee4d5051c5d86299f1f3d7dbf3475ad5",
+                    "url": "https://www.mellanox.com/downloads/DOCA/DOCA_v3.3.0/host/doca-host_3.3.0-088000-26.01-ubuntu2204_amd64.deb"
+                },
                 "version": "3.2.1",
                 "sha256": "f16f08572b3b2f513b80af66c881c6a60c19e74f0da50afafaa42b0c34116533",
                 "url": "https://www.mellanox.com/downloads/DOCA/DOCA_v3.2.1/host/doca-host_3.2.1-044000-25.10-ubuntu2404_amd64.deb"

--- a/versions.json
+++ b/versions.json
@@ -21,6 +21,11 @@
     "doca": {
         "ubuntu22.04": {
             "x86_64": {
+                "nvidia_v100": {
+                    "version": "3.3.0",
+                    "sha256": "2310b597cb2bb1b70c8db1b0641ac531ee4d5051c5d86299f1f3d7dbf3475ad5",
+                    "url": "https://www.mellanox.com/downloads/DOCA/DOCA_v3.3.0/host/doca-host_3.3.0-088000-26.01-ubuntu2204_amd64.deb"
+                },
                 "version": "3.2.1",
                 "sha256": "75b8d4258b7239ef5021abaa25e7eeb4fcbc0c8117cab89ce1a766d2d218c8a0",
                 "url": "https://www.mellanox.com/downloads/DOCA/DOCA_v3.2.1/host/doca-host_3.2.1-044000-25.10-ubuntu2204_amd64.deb"
@@ -107,9 +112,9 @@
             },
             "x86_64": {
                 "nvidia_v100": {
-                    "version": "2.25.1",
-                    "sha256": "12dced766fee0946210693ab7ee8b7a7491082a775db837bcfd73323f155e4a7",
-                    "url": "https://content.mellanox.com/hpc/hpc-x/v2.25.1_cuda12/hpcx-v2.25.1-gcc-doca_ofed-ubuntu24.04-cuda12-x86_64.tbz"
+                    "version": "2.26",
+                    "sha256": "55fc0b15041e1f7007c10aea2c3e5a42979e7c15682d050da5dcc5b21846e84e",
+                    "url": "https://content.mellanox.com/hpc/hpc-x/v2.26_cuda12/hpcx-v2.26-gcc-doca_ofed-ubuntu24.04-cuda12-x86_64.tbz"
                 },
                 "version": "2.25.1",
                 "sha256": "8767bea4f0967a6b0f5e1b31395a431bf5624eaf34c928f109bc2db985f26887",
@@ -295,7 +300,7 @@
         "ubuntu24.04": {
             "x86_64": {
                 "driver": {
-                    "version": "580.126.16"
+                    "version": "590.48.01"
                 }
             },
             "aarch64": {
@@ -600,8 +605,8 @@
                 "distribution": "Ubuntu24_04"
             },
             "x86_64": {
-                "version": "2.5.1-1",
-                "commit": "0f7366e73b019e7facf907381f6b0b2f5a1576e4",
+                "version": "2.5.2-1",
+                "commit": "c91ad9f178e5fb729fc5b6dc62a77c3bb364d6c9",
                 "distribution": "Ubuntu24_04"
             }
         },

--- a/versions.json
+++ b/versions.json
@@ -28,14 +28,9 @@
         },
         "ubuntu24.04": {
             "x86_64": {
-                "nvidia_v100": {
-                    "version": "3.3.0",
-                    "sha256": "2310b597cb2bb1b70c8db1b0641ac531ee4d5051c5d86299f1f3d7dbf3475ad5",
-                    "url": "https://www.mellanox.com/downloads/DOCA/DOCA_v3.3.0/host/doca-host_3.3.0-088000-26.01-ubuntu2204_amd64.deb"
-                },
-                "version": "3.2.1",
-                "sha256": "f16f08572b3b2f513b80af66c881c6a60c19e74f0da50afafaa42b0c34116533",
-                "url": "https://www.mellanox.com/downloads/DOCA/DOCA_v3.2.1/host/doca-host_3.2.1-044000-25.10-ubuntu2404_amd64.deb"
+                "version": "3.3.0",
+                "sha256": "2310b597cb2bb1b70c8db1b0641ac531ee4d5051c5d86299f1f3d7dbf3475ad5",
+                "url": "https://www.mellanox.com/downloads/DOCA/DOCA_v3.3.0/host/doca-host_3.3.0-088000-26.01-ubuntu2204_amd64.deb"
             },
             "aarch64": {
                 "version": "3.2.1",
@@ -300,7 +295,7 @@
         "ubuntu24.04": {
             "x86_64": {
                 "driver": {
-                    "version": "590.48.01"
+                    "version": "580.126.16"
                 }
             },
             "aarch64": {


### PR DESCRIPTION
Ubuntu 24.04 V100 March 26 refresh:
- Updating gdrcopy from 2.5.1 to 2.5.2