### PR TITLE
Add OpenSSL multiarch support for Ubuntu

### DIFF
--- a/components/install_dynolog_drl.sh
+++ b/components/install_dynolog_drl.sh
@@ -121,6 +121,10 @@ EOF
             -DOPENSSL_INCLUDE_DIR=/usr/include/openssl3 \
             -DOPENSSL_CRYPTO_LIBRARY=/usr/lib64/openssl3/libcrypto.so \
             -DOPENSSL_SSL_LIBRARY=/usr/lib64/openssl3/libssl.so
+    elif [[ $DISTRIBUTION == *"ubuntu"* ]]; then
+        # On Ubuntu, OpenSSL libs are in the multiarch path, not /usr/lib or /usr/lib64
+        export OPENSSL_LIB_DIR=/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)
+        cmake .. -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release
     else
         cmake .. -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release
     fi


### PR DESCRIPTION
Fixing the bug where dyno failed to find openssl for ubuntu also:
OpenSSL libdir at `["/usr/include/../lib64", "/usr/include/../lib"]` does not contain the required files to either statically or dynamically link OpenSSL
https://dev.azure.com/hpc-platform-team/hpc-image-val/_build/results?buildId=31028&view=logs&j=2e985d55-ce88-5f0d-2e8a-908bf0ea94b7&t=ea2e6eb5-7ade-5086-6c60-7000dc5145bb