### PR TITLE
Ubuntu22.04 A100 April refresh

### DIFF
--- a/components/install_doca.sh
+++ b/components/install_doca.sh
@@ -22,7 +22,14 @@ Pin-Priority: -1
 PIN
 
     apt-get update
-    apt-get -y install doca-ofed
+if [[ $DISTRIBUTION == "ubuntu22.04" ]]; then
+    # Replace doca-ofed with MLNX_OFED component packages
+    # doca-ofed was removed in favor of installing explicit MLNX_OFED, kernel, RDMA, and userspace components
+    # This avoids hard OpenMPI dependencies and pmix(Microsoft Slurm repo packaging) conflicts with doca-ofed
+    apt-get install -y mlnx-ofed-kernel-dkms mlnx-ofed-kernel-utils  ofed-scripts dpcp ibacm ibarr ibdump ibsim ibsim-doc ibutils2 ibverbs-providers ibverbs-utils infiniband-diags iser-dkms isert-dkms kernel-mft-dkms knem knem-dkms libfuse2 libibmad-dev libibmad5 libibnetdisc5 libibumad-dev libibumad3 libibverbs-dev libibverbs1 libopensm libopensm-devel librdmacm-dev librdmacm1 mft mft-mlx5 mft-nvredfish mlnx-ethtool mlnx-iproute2 opensm opensm-doc perftest rdma-core rdmacm-utils rshim  sharp srp-dkms srptools ucx xpmem xpmem-dkms libiberty-dev
+else
+    apt-get install -y doca-ofed
+fi
 elif [[ $DISTRIBUTION == "azurelinux3.0" ]]; then
     rpm -i $DOCA_FILE
     dnf clean all

--- a/components/install_nvidiagpudriver.sh
+++ b/components/install_nvidiagpudriver.sh
@@ -136,7 +136,20 @@ if [[ "$DISTRIBUTION" != *-aks ]]; then
     tar -xvf ${TARBALL}
     pushd ./cuda-samples-${CUDA_SAMPLES_VERSION}
     mkdir build && cd build
-    cmake -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc ..
+
+    # DOCA's Ubuntu MPI packages can expose an invalid include path
+    # Force CMake to use the Open MPI built earlier in the image pipeline.
+    ompi_metadata=$(get_component_config "ompi")
+    OMPI_VERSION=$(jq -r '.version' <<< $ompi_metadata) 
+    OMPI_ROOT=/opt/openmpi-${OMPI_VERSION}
+    export PATH=${OMPI_ROOT}/bin:$PATH
+    export LD_LIBRARY_PATH=${OMPI_ROOT}/lib:$LD_LIBRARY_PATH
+
+    cmake -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
+          -DMPI_HOME=${OMPI_ROOT} \
+          -DCMAKE_PREFIX_PATH=${OMPI_ROOT} \
+          -DMPI_C_COMPILER=/opt/openmpi-${OMPI_VERSION}/bin/mpicc \
+          -DMPI_CXX_COMPILER=/opt/openmpi-${OMPI_VERSION}/bin/mpicxx ..
     make -j $(nproc)
     mv -vT ./Samples /usr/local/cuda-${CUDA_DRIVER_VERSION}/samples # Use the same version as the CUDA toolkit as thats where samples is being moved to
     popd

--- a/packer/scripts/prerequisites.sh
+++ b/packer/scripts/prerequisites.sh
@@ -208,20 +208,56 @@ install_ubuntu_lts_kernel() {
             
         22.04)
             apt update
-            apt install -y linux-azure-lts-22.04
-            apt-mark hold linux-azure-lts-22.04
             
+            if [[ "${KERNEL_VERSION}" == "5.15" ]]; then
+                echo "Installing default Ubuntu 22.04 Azure LTS kernel"
+        
+                apt install -y linux-azure-lts-22.04
+                apt-mark hold linux-azure-lts-22.04
+                
+               local kernel_version=$(dpkg-query -l | grep linux-azure-lts-22.04 | awk '{print $3}' | awk -F. 'OFS="." {print $1,$2,$3,$4}' | sed 's/\(.*\)\./\1-/') 
+            else
+                echo "Installing specified kernel version ${KERNEL_VERSION} for Ubuntu 22.04"                
+                if [[ "${KERNEL_VERSION}" != *-azure ]]; then
+                    echo "ERROR: KERNEL_VERSION must end with '-azure' on Ubuntu 22.04"
+                    exit 1
+                fi
+                local kernel_version="${KERNEL_VERSION%-azure}"
+
+                apt-get install -y \
+                    linux-image-${KERNEL_VERSION} \
+                    linux-modules-${KERNEL_VERSION} \
+                    linux-modules-extra-${KERNEL_VERSION} \
+                    linux-headers-${KERNEL_VERSION} \
+                    linux-tools-${KERNEL_VERSION} \
+                    linux-cloud-tools-${KERNEL_VERSION} \
+                    linux-azure-cloud-tools-${kernel_version} \
+                    linux-azure-headers-${kernel_version} \
+                    linux-azure-tools-${kernel_version}
+                apt-mark hold \
+                    linux-image-${KERNEL_VERSION} \
+                    linux-modules-${KERNEL_VERSION} \
+                    linux-modules-extra-${KERNEL_VERSION} \
+                    linux-headers-${KERNEL_VERSION} \
+                    linux-tools-${KERNEL_VERSION} \
+                    linux-cloud-tools-${KERNEL_VERSION} \
+                    linux-azure-cloud-tools-${kernel_version} \
+                    linux-azure-headers-${kernel_version} \
+                    linux-azure-tools-${kernel_version} 
+
+                apt-get autoremove -y
+            fi
+
             # Purge non-LTS kernels
             apt-get purge -y \
                 linux-azure linux-image-azure \
                 "linux-image-6.*" "linux-azure-6.*" \
                 "linux-cloud-tools-6.*" "linux-headers-6.*" \
                 "linux-modules-6.*" "linux-tools-6.*"
-            
+
             apt upgrade -y
-            
             # Set default kernel
-            local kernel_version=$(dpkg-query -l | grep linux-azure-lts-22.04 | awk '{print $3}' | awk -F. 'OFS="." {print $1,$2,$3,$4}' | sed 's/\(.*\)\./\1-/')
+            echo "Setting default kernel to ${kernel_version}-azure"
             grub-set-default "Advanced options for Ubuntu>Ubuntu, with Linux ${kernel_version}-azure"
             update-grub
             ;;

--- a/versions.json
+++ b/versions.json
@@ -21,9 +21,9 @@
     "doca": {
         "ubuntu22.04": {
             "x86_64": {
-                "version": "3.2.1",
-                "sha256": "75b8d4258b7239ef5021abaa25e7eeb4fcbc0c8117cab89ce1a766d2d218c8a0",
-                "url": "https://www.mellanox.com/downloads/DOCA/DOCA_v3.2.1/host/doca-host_3.2.1-044000-25.10-ubuntu2204_amd64.deb"
+                "version": "3.2.2",
+                "sha256": "9ef5dfc906c0a692b8c52d2f62c27badc7a0870c0993a2f5a429eea3371622fd",
+                "url": "https://www.mellanox.com/downloads/DOCA/DOCA_v3.2.2/host/doca-host_3.2.2-035000-25.10-ubuntu2204_amd64.deb"
             }
         },
         "ubuntu24.04": {
@@ -285,6 +285,13 @@
             "version": "5.0.9",
             "sha256": "be35ac3aae68609dedf56a3c6480cb1b0af9ae40b98cc83ef27bc859084a9aa8",
             "url": "https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.9.tar.gz"
+        },
+        "ubuntu22.04": {
+            "x86_64": {
+                "version": "5.0.10",
+                "sha256": "5692cc80554a7117c99eaa725d35100edd8bbf73423a5e265ff867979192df7d",
+                "url": "https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.10.tar.gz"
+            }
         }
     },
     "impi": {
@@ -298,7 +305,7 @@
         "ubuntu22.04": {
             "x86_64": {
                 "driver": {
-                    "version": "580.126.16"
+                    "version": "580.126.20"
                 }
             }
         },
@@ -598,8 +605,8 @@
     "gdrcopy": {
         "ubuntu22.04": {
             "x86_64": {
-                "version": "2.5.1-1",
-                "commit": "0f7366e73b019e7facf907381f6b0b2f5a1576e4",
+                "version": "2.5.2-1",
+                "commit": "c91ad9f178e5fb729fc5b6dc62a77c3bb364d6c9",
                 "distribution": "Ubuntu22_04"
             }
         },
@@ -672,7 +679,7 @@
     },
     "nccl": {
         "common": {
-            "version": "2.28.9-1",
+            "version": "2.30.3-1",
             "rdmasharpplugins": {
                 "commit": "master"
             }
@@ -704,6 +711,12 @@
         "common": {
             "version": "0.8",
             "url": "https://github.com/NVIDIA/nvbandwidth"
+        },
+        "ubuntu22.04": {
+            "x86_64": {
+                "version": "0.9",
+                "url": "https://github.com/NVIDIA/nvbandwidth"
+            }
         },
         "azurelinux3.0": {
             "aarch64": {


### PR DESCRIPTION
- Packer: add custom KERNEL_VERSION support for u22
- Component update:
  - NVIDIA driver: 580.126.16 -> 580.126.20
  - DOCA: 3.2.1 -> 3.2.2
  - OMPI: 5.0.9 -> 5.0.10
  - NCCL: 2.28.9-1 -> 2.30.3-1
  - GDRCopy: 2.5.1-1 -> 2.5.2-1
  - NVBandwidth: 0.8 -> 0.9