### PR TITLE
fix(azl3): handle containerd 2.1.5+ SystemdCgroup config and socket readiness

### DIFF
--- a/components/install_docker.sh
+++ b/components/install_docker.sh
@@ -28,6 +28,12 @@ systemctl restart docker
 # restart containerd service
 systemctl restart containerd
 
+# wait for containerd socket to be ready, recheck every second up to 30s
+for i in $(seq 1 30); do
+    [ -S /run/containerd/containerd.sock ] && break
+    sleep 1
+done
+
 # status of containerd snapshotter plugins
 ctr plugin ls
 

--- a/components/install_nvidia_container_toolkit.sh
+++ b/components/install_nvidia_container_toolkit.sh
@@ -60,6 +60,15 @@ if [ "$SKU" == "GB200" ]; then
     sed -i 's/enable_cdi = false/enable_cdi = true/g' /etc/containerd/conf.d/*.toml 2>/dev/null || true
 fi
 if [[ $DISTRIBUTION == "azurelinux3.0" ]]; then
-    sed -i '/\[plugins\.\"io\.containerd\.cri\.v1\.runtime\".containerd\.runtimes\.runc\.options\]/a \ \ \ \ \ \ \ \ \ \ \ \ SystemdCgroup = true' /etc/containerd/config.toml
-    sed -i '/\[plugins\.\"io\.containerd\.cri\.v1\.runtime\".containerd\.runtimes\.nvidia\.options\]/a \ \ \ \ \ \ \ \ \ \ \ \ SystemdCgroup = true' /etc/containerd/config.toml
+    # Enable SystemdCgroup for runc and nvidia runtimes.
+    # containerd 2.1.5+ includes SystemdCgroup in its default config
+    # (see https://github.com/containerd/containerd/pull/12244), so we
+    # replace false to true. Older versions omit the key entirely, so we
+    # append it instead.
+    if grep -q 'SystemdCgroup' /etc/containerd/config.toml; then
+        sed -i 's/SystemdCgroup = false/SystemdCgroup = true/g' /etc/containerd/config.toml
+    else
+        sed -i '/\[plugins\.\"io\.containerd\.cri\.v1\.runtime\".containerd\.runtimes\.runc\.options\]/a \ \ \ \ \ \ \ \ \ \ \ \ SystemdCgroup = true' /etc/containerd/config.toml
+        sed -i '/\[plugins\.\"io\.containerd\.cri\.v1\.runtime\".containerd\.runtimes\.nvidia\.options\]/a \ \ \ \ \ \ \ \ \ \ \ \ SystemdCgroup = true' /etc/containerd/config.toml
+    fi
 fi


### PR DESCRIPTION
The upcoming AzureLinux3 May release will update the containerd version from 2.0.0 to 2.1.6, which requires the following changes in the HPC AzureLinux 3 image build flow:
- containerd 2.1.5+ includes SystemdCgroup in its default config output. The previous `sed` logic created duplicate TOML keys, causing containerd to crash on startup. Update the logic to replace the key when it exists, and fall back to append for older versions. (ref: https://github.com/containerd/containerd/pull/12244)
- We observed that containerd 2.1+ takes longer to create its socket compared to containerd 2.0. To avoid a race condition, add a wait-and-check mechanism before calling `ctr plugin ls` immediately after restarting containerd.

Validation:
- azl internal hpc image build pipeline with this change: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1100953&view=results