### PR TITLE
Pin baremetal NVIDIA driver to previous version

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -365,6 +365,28 @@
                 }
             },
             "aarch64": {
+                "nvidia_gb200": {
+                    "baremetal": {
+                        "driver": {
+                            "version": "580.105.08",
+                            "major_version": "580"
+                        },
+                        "imex": {
+                            "version": "580.105.08-1"
+                        }
+                    }
+                },
+                "nvidia_gb300": {
+                    "baremetal": {
+                        "driver": {
+                            "version": "580.105.08",
+                            "major_version": "580"
+                        },
+                        "imex": {
+                            "version": "580.105.08-1"
+                        }
+                    }
+                },
                 "driver": {
                     "version": "580.126.20",
                     "major_version": "580"


### PR DESCRIPTION
Until it is validates in Canary GB200 and GB300 we can't move to 126 nvidia driver for baremetal.