### PR TITLE
fix: fix ldconfig caching for DCGM lib on Azl + add sudo to guardrail tdnf cache management

### DIFF
--- a/components/install_dynolog_drl.sh
+++ b/components/install_dynolog_drl.sh
@@ -83,6 +83,7 @@ if [[ "$GPU" == "NVIDIA" ]]; then
     popd
     rm -rf /tmp/dynolog
 
+    ldconfig
     DCGM_LIB=$(ldconfig -p | awk '/libdcgm\.so(\.[0-9]+)* / {print $NF; exit}')
     [[ -z "$DCGM_LIB" ]] && { echo "FATAL: libdcgm.so not found"; exit 1; }
 

--- a/tests/test-definitions.sh
+++ b/tests/test-definitions.sh
@@ -389,7 +389,7 @@ function verify_pssh_installation {
     case ${ID} in
         ubuntu) dpkg -l | grep pssh;;
         almalinux|rocky|rhel) dnf list installed | grep pssh;;
-        azurelinux) tdnf list installed | grep pssh;;
+        azurelinux) sudo tdnf list installed | grep pssh;;
         * ) ;;
     esac
     check_exit_code "PSSH Installed" "PSSH not installed!"
@@ -405,7 +405,7 @@ function verify_dcgm_installation {
     case ${ID} in
         ubuntu) dpkg -l | grep datacenter-gpu-manager;;
         almalinux|rocky|rhel) dnf list installed | grep datacenter-gpu-manager;;
-        azurelinux) tdnf list installed | grep datacenter-gpu-manager;;
+        azurelinux) sudo tdnf list installed | grep datacenter-gpu-manager;;
         * ) ;;
     esac
     check_exit_code "DCGM Installed" "DCGM not installed!"


### PR DESCRIPTION
This PR involves two fixes:
- Run ldconfig to refresh the dynamic linker cache before dynamically querying the location of DCGM shared lib
- Add sudo for tdnf list installed operations in tests/test-definitions.sh to ensure that the tdnf cache will always be correctly populated/refreshed given this script is executed without root mode during the packer image build