### PR TITLE
Fix doca installation bug from missing command

### DIFF
--- a/utils/set_properties.sh
+++ b/utils/set_properties.sh
@@ -73,3 +73,5 @@ fi
 
 # Component Versions
 export COMPONENT_VERSIONS=$(jq -r . $TOP_DIR/versions.json)
+
+source ${UTILS_DIR}/utilities.sh

--- a/utils/utilities.sh
+++ b/utils/utilities.sh
@@ -130,11 +130,6 @@ function sku_has_infiniband {
     ! _is_ncv6_sku
 }
 
-# Whether the current SKU has NVLink/NVSwitch fabric.
-function sku_has_nvlink {
-    ! _is_ncv6_sku
-}
-
 # Whether this SKU uses UCX as its MPI transport layer.
 function sku_uses_ucx {
     ! _is_ncv6_sku


### PR DESCRIPTION
- Source utilities.sh in `set_properties` so that `sku_has_infiniband` does not quietly fail with 'command not found' leading to DOCA not being installed on SKUs where it should be
- Remove dead function