### PR TITLE
hpc-tuning: extend GB200 TCP buffer + NUMA tuning to GB300

### DIFF
--- a/components/hpc-tuning.sh
+++ b/components/hpc-tuning.sh
@@ -25,7 +25,7 @@ elif [[ $DISTRIBUTION == "azurelinux3.0" ]]; then
     if tdnf list installed azsec-monitor >/dev/null 2>&1; then tdnf remove -y azsec-monitor; fi
 fi
 
-if [[ "$SKU" == "GB200" ]]; then 
+if [[ "$SKU" == "GB200" || "$SKU" == "GB300" ]]; then
     echo "net.core.rmem_max = 2147483647" >> /etc/sysctl.conf
     echo "net.core.wmem_max = 2147483647" >> /etc/sysctl.conf
     echo "net.ipv4.tcp_rmem = 4096 67108864 1073741824" >> /etc/sysctl.conf


### PR DESCRIPTION
## Summary

Extends the existing GB200-only sysctl + systemd tuning block in `components/hpc-tuning.sh` to also apply to GB300, which shares the same Grace‑Blackwell architecture and high‑bandwidth network profile.

## Problem

`components/hpc-tuning.sh` currently gates a block of TCP socket buffer and systemd NUMA-binding settings on `SKU == "GB200"`. GB300 falls through and inherits the stock Ubuntu kernel defaults:

| sysctl | Ubuntu default | GB200 (today) | GB300 (today, this fix) |
|---|---|---|---|
| `net.core.rmem_max` | ~208 KB | 2 GiB | ~208 KB → **2 GiB** |
| `net.core.wmem_max` | ~208 KB | 2 GiB | ~208 KB → **2 GiB** |
| `net.ipv4.tcp_rmem` max | 6 MiB | 1 GiB | 6 MiB → **1 GiB** |
| `net.ipv4.tcp_wmem` max | 4 MiB | 1 GiB | 4 MiB → **1 GiB** |

Because `tcp_rmem`'s max is clamped by `rmem_max`, GB300 connections cannot grow the receive buffer beyond a few hundred KB, so the advertised TCP receive window stays very small. For a high‑BDP flow (e.g. Azure Blob Storage), this manifests as repeated `send → window full → ~RTT stall → ACK → resume` cycles, materially increasing read latency on GB300 while GB200 — with the larger ceilings — is unaffected.

The repo already introduced `SKU_FAMILY="gb-family"` in `utils/set_properties.sh` precisely to unify GB200/GB300 logic, but this site was never migrated.

## Change

```diff
-if [[ "$SKU" == "GB200" ]]; then
+if [[ "$SKU" == "GB200" || "$SKU" == "GB300" ]]; then
     echo "net.core.rmem_max = 2147483647" >> /etc/sysctl.conf
     echo "net.core.wmem_max = 2147483647" >> /etc/sysctl.conf
     echo "net.ipv4.tcp_rmem = 4096 67108864 1073741824" >> /etc/sysctl.conf
     echo "net.ipv4.tcp_wmem = 4096 67108864 1073741824" >> /etc/sysctl.conf

     echo "NUMAPolicy=bind" | tee -a /etc/systemd/system.conf
     echo "NUMAMask=0-1" | tee -a /etc/systemd/system.conf
 fi
```

(An alternative form `[[ "$SKU_FAMILY" == "gb-family" ]]` is also viable and arguably cleaner; happy to switch to it if preferred.)

## Test plan

On a freshly built GB300 image:

```bash
sysctl net.core.rmem_max net.core.wmem_max net.ipv4.tcp_rmem net.ipv4.tcp_wmem
# expected:
# net.core.rmem_max = 2147483647
# net.core.wmem_max = 2147483647
# net.ipv4.tcp_rmem = 4096 67108864 1073741824
# net.ipv4.tcp_wmem = 4096 67108864 1073741824

grep -E "^NUMA(Policy|Mask)" /etc/systemd/system.conf
# expected:
# NUMAPolicy=bind
# NUMAMask=0-1
```

Latency / throughput against Azure Blob Storage should match the GB200 baseline after the fix.

## Scope

This PR is intentionally limited to the TCP buffer + NUMA tuning block. There are other `SKU == "GB200"` sites in the repo that likely need the same treatment (driver script routing in `distros/ubuntu24.04/install.sh` and `install_aks.sh`, CDI enablement in `components/install_nvidia_container_toolkit.sh`, packer `gpu_sku == "GB200"` checks, etc.); those will be addressed in separate PRs.
