### PR TITLE
Restore 580.126 NVIDIA driver for baremetal GB200/GB300

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -384,22 +384,22 @@
                 "nvidia_gb200": {
                     "baremetal": {
                         "driver": {
-                            "version": "580.105.08",
+                            "version": "580.126.20",
                             "major_version": "580"
                         },
                         "imex": {
-                            "version": "580.105.08-1"
+                            "version": "580.126.20-1"
                         }
                     }
                 },
                 "nvidia_gb300": {
                     "baremetal": {
                         "driver": {
-                            "version": "580.105.08",
+                            "version": "580.126.20",
                             "major_version": "580"
                         },
                         "imex": {
-                            "version": "580.105.08-1"
+                            "version": "580.126.20-1"
                         }
                     }
                 },


### PR DESCRIPTION
Update the SKU-scoped Ubuntu 24.04 aarch64 baremetal overrides for GB200 and GB300 to NVIDIA driver 580.126.20 and align IMEX to 580.126.20-1.