### PR TITLE
Bump pmix to 4.2.9-2

### DIFF
--- a/components/install_doca.sh
+++ b/components/install_doca.sh
@@ -23,6 +23,22 @@ PIN
 
     apt-get update
     apt-get -y install doca-ofed
+
+    # Mark doca-ofed's dependencies (the OFED userspace + kernel modules) as
+    # manually-installed so they survive any subsequent `apt autoremove`.
+    # Later components (e.g. install_pmix.sh installing libevent-dev/libhwloc-dev)
+    # may remove the doca-ofed meta-package due to conflicts with openmpi, which
+    # would otherwise leave the entire OFED stack flagged auto-installed and
+    # liable to be swept away by autoremove (e.g. in install_dynolog_drl.sh).
+    # Scoped to Ubuntu 22.04 where this conflict has been observed.
+    if [[ $DISTRIBUTION == "ubuntu22.04" ]]; then
+        DOCA_OFED_DEPS=$(apt-cache depends --recurse --no-recommends --no-suggests \
+            --no-conflicts --no-breaks --no-replaces --no-enhances doca-ofed \
+            2>/dev/null | awk '/^\w/ {print $1}' | sort -u)
+        if [[ -n "$DOCA_OFED_DEPS" ]]; then
+            apt-mark manual $DOCA_OFED_DEPS || true
+        fi
+    fi
 elif [[ $DISTRIBUTION == "azurelinux3.0" ]]; then
     rpm -i $DOCA_FILE
     dnf clean all

--- a/components/install_doca.sh
+++ b/components/install_doca.sh
@@ -23,22 +23,6 @@ PIN
 
     apt-get update
     apt-get -y install doca-ofed
-
-    # Mark doca-ofed's dependencies (the OFED userspace + kernel modules) as
-    # manually-installed so they survive any subsequent `apt autoremove`.
-    # Later components (e.g. install_pmix.sh installing libevent-dev/libhwloc-dev)
-    # may remove the doca-ofed meta-package due to conflicts with openmpi, which
-    # would otherwise leave the entire OFED stack flagged auto-installed and
-    # liable to be swept away by autoremove (e.g. in install_dynolog_drl.sh).
-    # Scoped to Ubuntu 22.04 where this conflict has been observed.
-    if [[ $DISTRIBUTION == "ubuntu22.04" ]]; then
-        DOCA_OFED_DEPS=$(apt-cache depends --recurse --no-recommends --no-suggests \
-            --no-conflicts --no-breaks --no-replaces --no-enhances doca-ofed \
-            2>/dev/null | awk '/^\w/ {print $1}' | sort -u)
-        if [[ -n "$DOCA_OFED_DEPS" ]]; then
-            apt-mark manual $DOCA_OFED_DEPS || true
-        fi
-    fi
 elif [[ $DISTRIBUTION == "azurelinux3.0" ]]; then
     rpm -i $DOCA_FILE
     dnf clean all

--- a/components/install_doca.sh
+++ b/components/install_doca.sh
@@ -22,6 +22,46 @@ Pin-Priority: -1
 PIN
 
     apt-get update
+
+    # doca-ofed strict-pins `openmpi (= <doca-version>)` which pulls in the DOCA-bundled
+    # Open MPI .deb. We never use that binary at runtime — HPC-X (installed later by
+    # install_mpis.sh) provides Open MPI at /opt — and the .deb ships
+    # /etc/pmix-mca-params.conf, colliding with the pmix package installed by
+    # install_pmix.sh (pmix >=4.2.9-2 dropped its `Conflicts: openmpi`, so dpkg now
+    # aborts with "trying to overwrite /etc/pmix-mca-params.conf").
+    #
+    # Inhibit the DOCA openmpi by installing an empty equivs marker that
+    # `Provides: openmpi (= <doca-version>)`, satisfying doca-ofed's strict-equality
+    # dep so apt never pulls in the real openmpi .deb. Same pattern as
+    # ucx-provides-libucx0 in install_rocm.sh.
+    apt-get install -y equivs
+    openmpi_version=$(apt-cache show openmpi 2>/dev/null | awk '/^Version:/ {print $2; exit}')
+    if [[ -z "$openmpi_version" ]]; then
+        echo "ERROR: could not read openmpi version from DOCA repo" >&2
+        exit 1
+    fi
+    cat > /tmp/hpcx-provides-openmpi <<EOF
+Section: misc
+Priority: optional
+Homepage: https://github.com/Azure/azhpc-images
+Standards-Version: 3.9.2
+
+Package: hpcx-provides-openmpi
+Provides: openmpi (= ${openmpi_version})
+Version: ${openmpi_version}
+Maintainer: Azure HPC Platform team <hpcplat@microsoft.com>
+Description: marker package to inhibit the DOCA-bundled openmpi
+ HPC-X (installed by install_mpis.sh into /opt) provides Open MPI at runtime,
+ so the DOCA openmpi .deb is redundant and additionally collides with
+ /etc/pmix-mca-params.conf from the separately-installed pmix package.
+EOF
+    (
+        cd /tmp
+        equivs-build /tmp/hpcx-provides-openmpi
+        dpkg -i /tmp/hpcx-provides-openmpi_*_all.deb
+    )
+    rm -f /tmp/hpcx-provides-openmpi_*_all.deb /tmp/hpcx-provides-openmpi
+
     apt-get -y install doca-ofed
 elif [[ $DISTRIBUTION == "azurelinux3.0" ]]; then
     rpm -i $DOCA_FILE

--- a/versions.json
+++ b/versions.json
@@ -1018,7 +1018,7 @@
     },
     "pmix": {
         "common": {
-            "version": "4.2.9-1"
+            "version": "4.2.9-2"
         },
         "azurelinux3.0": {
             "x86_64": {


### PR DESCRIPTION
pmix 4.2.9-2 removed openmpi conflict with doca ofed and it's necessary for u22.04 build. 
Inhibit the DOCA openmpi by installing an empty equivs marker that `Provides: openmpi (= <doca-version>)`, satisfying doca-ofed's strict-equality dep so apt never pulls in the real openmpi .deb. Same pattern as ucx-provides-libucx0 in install_rocm.sh.