### PR TITLE
Always write kernel version to component_versions

### DIFF
--- a/components/install_health_checks.sh
+++ b/components/install_health_checks.sh
@@ -36,12 +36,3 @@ popd
 popd
 
 write_component_version "AZ_HEALTH_CHECKS" ${AZHC_VERSION}
-
-if [[ $DISTRIBUTION == "azurelinux3.0" ]]; then
-   kernel_version=$(rpm -q kernel | sed 's/kernel\-//g')
-   write_component_version "KERNEL" ${kernel_version::-12}
-   os_version=$(rpm -qf /etc/os-release)
-   write_component_version "OS" ${os_version::-12}
-else
-   write_component_version "KERNEL" $(uname -r)
-fi

--- a/components/write_os_versions.sh
+++ b/components/write_os_versions.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -ex
+
+source ${UTILS_DIR}/utilities.sh
+
+if [[ $DISTRIBUTION == "azurelinux3.0" ]]; then
+   kernel_version=$(rpm -q kernel | sed 's/kernel\-//g')
+   write_component_version "KERNEL" ${kernel_version::-12}
+   os_version=$(rpm -qf /etc/os-release)
+   write_component_version "OS" ${os_version::-12}
+else
+   write_component_version "KERNEL" $(uname -r)
+fi

--- a/distros/almalinux8.10/install.sh
+++ b/distros/almalinux8.10/install.sh
@@ -94,6 +94,9 @@ $COMPONENT_DIR/install_health_checks.sh "$GPU"
 # disable cloud-init
 $COMPONENT_DIR/disable_cloudinit.sh
 
+# record OS/kernel versions
+$COMPONENT_DIR/write_os_versions.sh
+
 # SKU Customization
 $COMPONENT_DIR/setup_sku_customizations.sh
 

--- a/distros/almalinux9.7/install.sh
+++ b/distros/almalinux9.7/install.sh
@@ -94,6 +94,9 @@ $COMPONENT_DIR/install_health_checks.sh "$GPU"
 # disable cloud-init
 $COMPONENT_DIR/disable_cloudinit.sh
 
+# record OS/kernel versions
+$COMPONENT_DIR/write_os_versions.sh
+
 # SKU Customization
 $COMPONENT_DIR/setup_sku_customizations.sh
 

--- a/distros/azurelinux3.0/install.sh
+++ b/distros/azurelinux3.0/install.sh
@@ -116,6 +116,8 @@ $COMPONENT_DIR/add-udev-rules.sh
 # copy test file
 $COMPONENT_DIR/copy_test_file.sh
 
+# record OS/kernel versions
+$COMPONENT_DIR/write_os_versions.sh
 
 # SKU Customization
 $COMPONENT_DIR/setup_sku_customizations.sh

--- a/distros/rocky8.10/install.sh
+++ b/distros/rocky8.10/install.sh
@@ -110,6 +110,9 @@ $COMPONENT_DIR/install_health_checks.sh "$GPU"
 # disable cloud-init
 $COMPONENT_DIR/disable_cloudinit.sh
 
+# record OS/kernel versions
+$COMPONENT_DIR/write_os_versions.sh
+
 # SKU Customization
 $COMPONENT_DIR/setup_sku_customizations.sh
 

--- a/distros/rocky9.7/install.sh
+++ b/distros/rocky9.7/install.sh
@@ -110,6 +110,9 @@ $COMPONENT_DIR/install_health_checks.sh "$GPU"
 # disable cloud-init
 $COMPONENT_DIR/disable_cloudinit.sh
 
+# record OS/kernel versions
+$COMPONENT_DIR/write_os_versions.sh
+
 # SKU Customization
 $COMPONENT_DIR/setup_sku_customizations.sh
 

--- a/distros/ubuntu22.04/install.sh
+++ b/distros/ubuntu22.04/install.sh
@@ -110,6 +110,9 @@ $COMPONENT_DIR/install_health_checks.sh "$GPU"
 # disable cloud-init
 $COMPONENT_DIR/disable_cloudinit.sh
 
+# record OS/kernel versions
+$COMPONENT_DIR/write_os_versions.sh
+
 # SKU Customization
 $COMPONENT_DIR/setup_sku_customizations.sh
 

--- a/distros/ubuntu24.04/install.sh
+++ b/distros/ubuntu24.04/install.sh
@@ -149,6 +149,9 @@ $COMPONENT_DIR/copy_test_file.sh
 # disable cloud-init
 $COMPONENT_DIR/disable_cloudinit.sh
 
+# record OS/kernel versions
+$COMPONENT_DIR/write_os_versions.sh
+
 # SKU Customization
 $COMPONENT_DIR/setup_sku_customizations.sh
 

--- a/partners/rhel/rhel-8.x/rhel-8.10-hpc/install.sh
+++ b/partners/rhel/rhel-8.x/rhel-8.10-hpc/install.sh
@@ -106,6 +106,9 @@ $COMMON_DIR/copy_test_file.sh
 # disable cloud-init
 $RHEL_COMMON_DIR/disable_cloudinit.sh
 
+# record OS/kernel versions
+$COMMON_DIR/write_os_versions.sh
+
 # SKU Customization
 $COMMON_DIR/setup_sku_customizations.sh
 


### PR DESCRIPTION
- Previously, the kernel version was only written to `component_versions.txt` during Azure Health Checks installation which is sometimes skipped. Write the version in a dedicated step instead.