### PR TITLE
Pin GB200/GB300 baremetal driver, IMEX, and DOCA versions

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -54,6 +54,20 @@
                 "url": "https://www.mellanox.com/downloads/DOCA/DOCA_v3.2.2/host/doca-host_3.2.2-035000-25.10-ubuntu2404_amd64.deb"
             },
             "aarch64": {
+                "nvidia_gb200": {
+                    "baremetal": {
+                        "version": "3.2.2",
+                        "sha256": "0343656f130b79b7392742f9f7890fb59d6a1489fa020ccab26adc714e727b04",
+                        "url": "https://www.mellanox.com/downloads/DOCA/DOCA_v3.2.2/host/doca-host_3.2.2-035000-25.10-ubuntu2404_arm64.deb"
+                    }
+                },
+                "nvidia_gb300": {
+                    "baremetal": {
+                        "version": "3.2.2",
+                        "sha256": "0343656f130b79b7392742f9f7890fb59d6a1489fa020ccab26adc714e727b04",
+                        "url": "https://www.mellanox.com/downloads/DOCA/DOCA_v3.2.2/host/doca-host_3.2.2-035000-25.10-ubuntu2404_arm64.deb"
+                    }
+                },
                 "version": "3.2.2",
                 "sha256": "0343656f130b79b7392742f9f7890fb59d6a1489fa020ccab26adc714e727b04",
                 "url": "https://www.mellanox.com/downloads/DOCA/DOCA_v3.2.2/host/doca-host_3.2.2-035000-25.10-ubuntu2404_arm64.deb"
@@ -384,11 +398,11 @@
                 "nvidia_gb200": {
                     "baremetal": {
                         "driver": {
-                            "version": "580.126.20",
+                            "version": "580.159.04",
                             "major_version": "580"
                         },
                         "imex": {
-                            "version": "580.126.20-1"
+                            "version": "580.159.04-1"
                         }
                     }
                 },


### PR DESCRIPTION
 GB200 baremetal (ubuntu24.04 / aarch64):
 - NVIDIA driver: 580.126.20 -> 580.159.04
 - NVIDIA IMEX:   580.126.20-1 -> 580.159.04-1

 GB200 & GB300 baremetal (ubuntu24.04 / aarch64):
 - DOCA: add explicit 3.2.2 pin (previously inherited from aarch64 arch-level default).

 The IMEX entry is informational metadata; the actual installed
 version is selected by the nvidia-driver-pinning-${DRIVER_VERSION}
 apt meta-package, which restricts all driver-related packages
 (including nvidia-imex) to the matching driver version.