### PR TITLE
patch DOCA on RHEL family and rip out o2ib from Lustre

### DIFF
--- a/components/install_doca.sh
+++ b/components/install_doca.sh
@@ -99,6 +99,7 @@ EOF
     rm -f /tmp/hpcx-provides-openmpi_*_all.deb /tmp/hpcx-provides-openmpi
 
     apt-get -y install doca-ofed
+    check_dkms_status mlnx-ofed-kernel iser isert srp
 elif [[ $DISTRIBUTION == "azurelinux3.0" ]]; then
     rpm -i $DOCA_FILE
     dnf clean all
@@ -113,6 +114,7 @@ else
     sed -i '/^exclude=/d' /etc/dnf/dnf.conf
     configure_mlnx_ofa_kernel_dkms_dpll_patch
     dnf -y install doca-ofed
+    check_dkms_status mlnx-ofa_kernel iser isert srp
     # Restore exclusion
     mv /etc/dnf/dnf.conf.bak /etc/dnf/dnf.conf
 

--- a/components/install_doca.sh
+++ b/components/install_doca.sh
@@ -11,6 +11,24 @@ DOCA_FILE=$(basename ${DOCA_URL})
 
 download_and_verify $DOCA_URL $DOCA_SHA256
 
+configure_mlnx_ofa_kernel_dkms_dpll_patch() {
+    local kernel_header=/usr/src/kernels/$(uname -r)/include/linux/dpll.h
+    local dkms_conf=/etc/dkms/mlnx-ofa_kernel.conf
+    local patch_file=${azhpc_dir}/components/patches/mlnx-ofa-kernel-dpll-ffo-param.patch
+    local patch_dir=/etc/dkms/mlnx-ofa_kernel/patches
+
+    # Alma/Rocky/RHEL 9.8 kernels use Red Hat's newer DPLL ffo_get callback
+    # signature, while DOCA 3.2.x / MLNX OFED 25.10 still ships the older one.
+    [[ -f "${kernel_header}" ]] || return 0
+    grep -q 'struct dpll_ffo_param \*ffo,' "${kernel_header}" || return 0
+
+    mkdir -p "${patch_dir}"
+    cp "${patch_file}" "${patch_dir}/dpll-ffo-param.patch"
+    cat > "${dkms_conf}" <<'EOF'
+PATCH[0]="dpll-ffo-param.patch"
+EOF
+}
+
 if [[ $DISTRIBUTION == *"ubuntu"* ]]; then
     dpkg -i $DOCA_FILE
 
@@ -93,6 +111,7 @@ else
     # Backup
     cp /etc/dnf/dnf.conf /etc/dnf/dnf.conf.bak
     sed -i '/^exclude=/d' /etc/dnf/dnf.conf
+    configure_mlnx_ofa_kernel_dkms_dpll_patch
     dnf -y install doca-ofed
     # Restore exclusion
     mv /etc/dnf/dnf.conf.bak /etc/dnf/dnf.conf

--- a/components/install_doca.sh
+++ b/components/install_doca.sh
@@ -14,7 +14,7 @@ download_and_verify $DOCA_URL $DOCA_SHA256
 configure_mlnx_ofa_kernel_dkms_dpll_patch() {
     local kernel_header=/usr/src/kernels/$(uname -r)/include/linux/dpll.h
     local dkms_conf=/etc/dkms/mlnx-ofa_kernel.conf
-    local patch_file=${azhpc_dir}/components/patches/mlnx-ofa-kernel-dpll-ffo-param.patch
+    local patch_file=${COMPONENT_DIR}/patches/mlnx-ofa-kernel-dpll-ffo-param.patch
     local patch_dir=/etc/dkms/mlnx-ofa_kernel/patches
 
     # Alma/Rocky/RHEL 9.8 kernels use Red Hat's newer DPLL ffo_get callback

--- a/components/install_lustre_client.sh
+++ b/components/install_lustre_client.sh
@@ -80,7 +80,11 @@ if [[ $DISTRIBUTION == *"ubuntu"* ]]; then
     #cp ./microsoft.gpg /etc/apt/trusted.gpg.d/
     apt-get update
 
+    LUSTRE_CLIENT_PACKAGE="lustre-client-${LUSTRE_VERSION}"
     LUSTRE_PACKAGE="amlfs-lustre-client-dkms-${LUSTRE_VERSION}"
+    # Install the userspace package first because it owns /etc/sysconfig/dkms-lustre.
+    # Pre-creating that conffile makes noninteractive dpkg stop at a prompt.
+    apt-get install -y "${LUSTRE_CLIENT_PACKAGE}"
     if [[ $UBUNTU_VERSION == 22.04 ]]; then
         configure_legacy_lustre_dkms_no_o2ib "${LUSTRE_VERSION}"
     else

--- a/components/install_lustre_client.sh
+++ b/components/install_lustre_client.sh
@@ -13,7 +13,28 @@ configure_lustre_dkms_no_o2ib() {
     mkdir -p "$(dirname "${config_file}")"
     cat > "${config_file}" <<'EOF'
 # Azure clients do not have IB line of sight to Lustre servers, so use TCP LNet.
-LUSTRE_DKMS_CONFIGURE_EXTRA="--with-o2ib=no"
+# EL DKMS captures stdout from sourcing this file into DKMS_CONFIG_OPTS.
+echo --with-o2ib=no
+EOF
+}
+
+configure_lustre_dkms_lu20071_patch() {
+    local module=lustre-client
+    local module_version=$1
+    local kernel_header=/lib/modules/$(uname -r)/build/include/linux/timer.h
+    local dkms_conf=/etc/dkms/${module}-${module_version}.conf
+    local patch_file=${COMPONENT_DIR}/patches/lustre-client-lu-20071-timer-container-of.patch
+    local patch_dir=/etc/dkms/${module}/patches
+
+    # RHEL 9.8 kernels 5.14.0-687+ dropped from_timer(); LU-20071 rewires
+    # Lustre's cfs_from_timer wrapper to timer_container_of.
+    [[ -f "${kernel_header}" ]] || return 0
+    grep -q 'from_timer' "${kernel_header}" && return 0
+
+    mkdir -p "${patch_dir}"
+    cp "${patch_file}" "${patch_dir}/lu-20071-timer-container-of.patch"
+    cat > "${dkms_conf}" <<'EOF'
+PATCH[0]="lu-20071-timer-container-of.patch"
 EOF
 }
 
@@ -112,6 +133,7 @@ else
         "lustre-client-${LUSTRE_VERSION_UNDERSCORE}-devel"
     )
     configure_lustre_dkms_no_o2ib /etc/sysconfig/lustre
+    configure_lustre_dkms_lu20071_patch "${LUSTRE_VERSION_UNDERSCORE}"
     dnf install -y --disableexcludes=main --refresh "${LUSTRE_PACKAGES[@]}"
     check_dkms_status lustre-client
     LUSTRE_VERSION=${LUSTRE_VERSION_UNDERSCORE}

--- a/components/install_lustre_client.sh
+++ b/components/install_lustre_client.sh
@@ -18,6 +18,39 @@ echo --with-o2ib=no
 EOF
 }
 
+install_cuda_dkms_3_4_1_for_jammy_amd() {
+    local dkms_url=https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/dkms_3.4.1-1ubuntu1_all.deb
+    local dkms_sha256=16ce508e74cbe8426fe19c1c56de5ea6e9f3dbe05d85ba5cbf5a8a271d34c2be
+    local dkms_deb=$(basename "${dkms_url}")
+    local current_version
+
+    [[ "${DISTRIBUTION}" == "ubuntu22.04" && "${GPU:-}" == "AMD" ]] || return 0
+
+    current_version=$(dkms --version 2>/dev/null | sed -n 's/^dkms-\(.*\)$/\1/p' || true)
+    if [[ -n "${current_version}" ]] && dpkg --compare-versions "${current_version}" ge 3.4.1; then
+        return 0
+    fi
+
+    rm -f "./${dkms_deb}"
+    download_and_verify "${dkms_url}" "${dkms_sha256}"
+    apt-get install -y "./${dkms_deb}"
+    rm -f "./${dkms_deb}"
+}
+
+configure_lustre_dkms_skip_artifact() {
+    local module=$1
+    local module_version=$2
+    local slot=$3
+    local description=$4
+    local dkms_conf=/etc/dkms/${module}-${module_version}.conf
+
+    mkdir -p "$(dirname "${dkms_conf}")"
+    cat >> "${dkms_conf}" <<EOF
+# ${description}
+BUILD_EXCLUSIVE_KERNEL[${slot}]="^$"
+EOF
+}
+
 configure_lustre_dkms_lu20071_patch() {
     local module=lustre-client
     local module_version=$1
@@ -33,7 +66,8 @@ configure_lustre_dkms_lu20071_patch() {
 
     mkdir -p "${patch_dir}"
     cp "${patch_file}" "${patch_dir}/lu-20071-timer-container-of.patch"
-    cat > "${dkms_conf}" <<'EOF'
+    mkdir -p "$(dirname "${dkms_conf}")"
+    cat >> "${dkms_conf}" <<'EOF'
 PATCH[0]="lu-20071-timer-container-of.patch"
 EOF
 }
@@ -66,24 +100,11 @@ configure_legacy_lustre_dkms_no_o2ib() {
     cat > "${dkms_conf}" <<'EOF'
 # Azure clients do not have IB line of sight to Lustre servers, so use TCP LNet.
 # Ubuntu 22.04's published AMLFS Lustre DKMS package has a static dkms.conf with
-# ko2iblnd in the expected module list, so override both configure and artifacts.
+# ko2iblnd in record 11, so configure without o2ib and skip only that artifact.
 MAKE="sh autogen.sh && ./configure --with-linux=$kernel_source_dir --with-linux-obj=$kernel_source_dir --disable-server --disable-quilt --disable-dependency-tracking --disable-doc --disable-utils --disable-iokit --disable-snmp --disable-tests --enable-quota --with-kmp-moddir=updates --with-o2ib=no --enable-gss && make"
-BUILT_MODULE_NAME[11]="ksocklnd"
-BUILT_MODULE_LOCATION[11]="lnet/klnds/socklnd"
-DEST_MODULE_LOCATION[11]="/updates/kernel/net/lustre"
-BUILT_MODULE_NAME[12]="libcfs"
-BUILT_MODULE_LOCATION[12]="libcfs/libcfs"
-DEST_MODULE_LOCATION[12]="/updates/kernel/net/lustre"
-BUILT_MODULE_NAME[13]="lnet"
-BUILT_MODULE_LOCATION[13]="lnet/lnet"
-DEST_MODULE_LOCATION[13]="/updates/kernel/net/lustre"
-BUILT_MODULE_NAME[14]="lnet_selftest"
-BUILT_MODULE_LOCATION[14]="lnet/selftest"
-DEST_MODULE_LOCATION[14]="/updates/kernel/net/lustre"
-BUILT_MODULE_NAME[15]="ptlrpc_gss"
-BUILT_MODULE_LOCATION[15]="lustre/ptlrpc/gss"
-DEST_MODULE_LOCATION[15]="/updates/kernel/fs/lustre"
 EOF
+    configure_lustre_dkms_skip_artifact "${module}" "${module_version}" 11 \
+        "Ubuntu 22.04 ko2iblnd is record 11; --with-o2ib=no intentionally skips it."
 }
 
 if [[ $DISTRIBUTION == *"ubuntu"* ]]; then
@@ -107,6 +128,7 @@ if [[ $DISTRIBUTION == *"ubuntu"* ]]; then
     # Pre-creating that conffile makes noninteractive dpkg stop at a prompt.
     apt-get install -y "${LUSTRE_CLIENT_PACKAGE}"
     if [[ $UBUNTU_VERSION == 22.04 ]]; then
+        install_cuda_dkms_3_4_1_for_jammy_amd
         configure_legacy_lustre_dkms_no_o2ib "${LUSTRE_VERSION}"
     else
         configure_lustre_dkms_no_o2ib_with_tr_workaround /etc/sysconfig/dkms-lustre
@@ -133,6 +155,8 @@ else
         "lustre-client-${LUSTRE_VERSION_UNDERSCORE}-devel"
     )
     configure_lustre_dkms_no_o2ib /etc/sysconfig/lustre
+    configure_lustre_dkms_skip_artifact lustre-client "${LUSTRE_VERSION_UNDERSCORE}" 3 \
+        "EL ko2iblnd is record 3; --with-o2ib=no intentionally skips it."
     configure_lustre_dkms_lu20071_patch "${LUSTRE_VERSION_UNDERSCORE}"
     dnf install -y --disableexcludes=main --refresh "${LUSTRE_PACKAGES[@]}"
     check_dkms_status lustre-client

--- a/components/install_lustre_client.sh
+++ b/components/install_lustre_client.sh
@@ -87,6 +87,7 @@ if [[ $DISTRIBUTION == *"ubuntu"* ]]; then
         configure_lustre_dkms_no_o2ib_with_tr_workaround /etc/sysconfig/dkms-lustre
     fi
     apt-get install -y "${LUSTRE_PACKAGE}"
+    check_dkms_status lustre-client-modules
 else
     # RHEL-family: AlmaLinux, Rocky Linux, RHEL, etc.
     LUSTRE_VERSION_UNDERSCORE=${LUSTRE_VERSION//-/_}
@@ -108,6 +109,7 @@ else
     )
     configure_lustre_dkms_no_o2ib /etc/sysconfig/lustre
     dnf install -y --disableexcludes=main --refresh "${LUSTRE_PACKAGES[@]}"
+    check_dkms_status lustre-client
     LUSTRE_VERSION=${LUSTRE_VERSION_UNDERSCORE}
 fi
 

--- a/components/install_lustre_client.sh
+++ b/components/install_lustre_client.sh
@@ -7,6 +7,64 @@ source ${UTILS_DIR}/utilities.sh
 lustre_metadata=$(get_component_config "lustre")
 LUSTRE_VERSION=$(jq -r '.version' <<< $lustre_metadata)
 
+configure_lustre_dkms_no_o2ib() {
+    local config_file=$1
+
+    mkdir -p "$(dirname "${config_file}")"
+    cat > "${config_file}" <<'EOF'
+# Azure clients do not have IB line of sight to Lustre servers, so use TCP LNet.
+LUSTRE_DKMS_CONFIGURE_EXTRA="--with-o2ib=no"
+EOF
+}
+
+configure_lustre_dkms_no_o2ib_with_tr_workaround() {
+    local config_file=$1
+
+    mkdir -p "$(dirname "${config_file}")"
+    cat > "${config_file}" <<'EOF'
+# Azure clients do not have IB line of sight to Lustre servers, so use TCP LNet.
+# TODO: Drop the tr() workaround after AMLFS publishes Lustre DKMS with LU-19792.
+OPTS=$(printf '%s\n' "${OPTS:-}" | sed -E 's#(^|[[:space:]])--with-o2ib=[^[:space:]]+##g')
+LUSTRE_DKMS_CONFIGURE_EXTRA="--with-o2ib=no"
+tr() {
+    if [[ $# -eq 2 && "$1" == " " && ( "$2" == "\\n" || "$2" == "\\\\n" ) ]]; then
+        command tr ' ' '\n'
+    else
+        command tr "$@"
+    fi
+}
+EOF
+}
+
+configure_legacy_lustre_dkms_no_o2ib() {
+    local module=lustre-client-modules
+    local module_version=$1
+    local dkms_conf=/etc/dkms/${module}-${module_version}.conf
+
+    mkdir -p /etc/dkms
+    cat > "${dkms_conf}" <<'EOF'
+# Azure clients do not have IB line of sight to Lustre servers, so use TCP LNet.
+# Ubuntu 22.04's published AMLFS Lustre DKMS package has a static dkms.conf with
+# ko2iblnd in the expected module list, so override both configure and artifacts.
+MAKE="sh autogen.sh && ./configure --with-linux=$kernel_source_dir --with-linux-obj=$kernel_source_dir --disable-server --disable-quilt --disable-dependency-tracking --disable-doc --disable-utils --disable-iokit --disable-snmp --disable-tests --enable-quota --with-kmp-moddir=updates --with-o2ib=no --enable-gss && make"
+BUILT_MODULE_NAME[11]="ksocklnd"
+BUILT_MODULE_LOCATION[11]="lnet/klnds/socklnd"
+DEST_MODULE_LOCATION[11]="/updates/kernel/net/lustre"
+BUILT_MODULE_NAME[12]="libcfs"
+BUILT_MODULE_LOCATION[12]="libcfs/libcfs"
+DEST_MODULE_LOCATION[12]="/updates/kernel/net/lustre"
+BUILT_MODULE_NAME[13]="lnet"
+BUILT_MODULE_LOCATION[13]="lnet/lnet"
+DEST_MODULE_LOCATION[13]="/updates/kernel/net/lustre"
+BUILT_MODULE_NAME[14]="lnet_selftest"
+BUILT_MODULE_LOCATION[14]="lnet/selftest"
+DEST_MODULE_LOCATION[14]="/updates/kernel/net/lustre"
+BUILT_MODULE_NAME[15]="ptlrpc_gss"
+BUILT_MODULE_LOCATION[15]="lustre/ptlrpc/gss"
+DEST_MODULE_LOCATION[15]="/updates/kernel/fs/lustre"
+EOF
+}
+
 if [[ $DISTRIBUTION == *"ubuntu"* ]]; then
     source /etc/lsb-release
     UBUNTU_VERSION=$(cat /etc/os-release | grep VERSION_ID | cut -d= -f2 | cut -d\" -f2)
@@ -23,6 +81,11 @@ if [[ $DISTRIBUTION == *"ubuntu"* ]]; then
     apt-get update
 
     LUSTRE_PACKAGE="amlfs-lustre-client-dkms-${LUSTRE_VERSION}"
+    if [[ $UBUNTU_VERSION == 22.04 ]]; then
+        configure_legacy_lustre_dkms_no_o2ib "${LUSTRE_VERSION}"
+    else
+        configure_lustre_dkms_no_o2ib_with_tr_workaround /etc/sysconfig/dkms-lustre
+    fi
     apt-get install -y "${LUSTRE_PACKAGE}"
 else
     # RHEL-family: AlmaLinux, Rocky Linux, RHEL, etc.
@@ -43,6 +106,7 @@ else
         "lustre-client-dkms-${LUSTRE_VERSION_UNDERSCORE}"
         "lustre-client-${LUSTRE_VERSION_UNDERSCORE}-devel"
     )
+    configure_lustre_dkms_no_o2ib /etc/sysconfig/lustre
     dnf install -y --disableexcludes=main --refresh "${LUSTRE_PACKAGES[@]}"
     LUSTRE_VERSION=${LUSTRE_VERSION_UNDERSCORE}
 fi

--- a/components/patches/lustre-client-lu-20071-timer-container-of.patch
+++ b/components/patches/lustre-client-lu-20071-timer-container-of.patch
@@ -1,0 +1,14 @@
+diff --git a/libcfs/include/libcfs/linux/linux-time.h b/libcfs/include/libcfs/linux/linux-time.h
+--- a/libcfs/include/libcfs/linux/linux-time.h
++++ b/libcfs/include/libcfs/linux/linux-time.h
+@@ -235,5 +235,9 @@
+ #ifdef HAVE_TIMER_SETUP
++#ifndef timer_container_of
++#define timer_container_of(var, callback_timer, timer_fieldname) \
++	container_of(callback_timer, typeof(*var), timer_fieldname)
++#endif
+ #define cfs_timer_cb_arg_t struct timer_list *
+ #define cfs_from_timer(var, callback_timer, timer_fieldname) \
+-	from_timer(var, callback_timer, timer_fieldname)
++	timer_container_of(var, callback_timer, timer_fieldname)
+ #define cfs_timer_setup(timer, callback, data, flags) \

--- a/components/patches/mlnx-ofa-kernel-dpll-ffo-param.patch
+++ b/components/patches/mlnx-ofa-kernel-dpll-ffo-param.patch
@@ -1,0 +1,22 @@
+diff --git a/drivers/net/ethernet/mellanox/mlx5/core/dpll.c b/drivers/net/ethernet/mellanox/mlx5/core/dpll.c
+--- a/drivers/net/ethernet/mellanox/mlx5/core/dpll.c
++++ b/drivers/net/ethernet/mellanox/mlx5/core/dpll.c
+@@ -331,7 +331,8 @@
+ #ifdef HAVE_DPLL_PIN_OPS_HAS_FFO_GET
+ static int mlx5_dpll_ffo_get(const struct dpll_pin *pin, void *pin_priv,
+ 			     const struct dpll_device *dpll, void *dpll_priv,
+-			     s64 *ffo, struct netlink_ext_ack *extack)
++			     struct dpll_ffo_param *ffo,
++			     struct netlink_ext_ack *extack)
+ {
+ 	struct mlx5_dpll_synce_status synce_status;
+ 	struct mlx5_dpll *mdpll = pin_priv;
+@@ -340,6 +341,7 @@
+ 	err = mlx5_dpll_synce_status_get(mdpll->mdev, &synce_status);
+ 	if (err)
+ 		return err;
+-	return mlx5_dpll_pin_ffo_get(&synce_status, ffo);
++	ffo->type = DPLL_FFO_PIN_DEVICE;
++	return mlx5_dpll_pin_ffo_get(&synce_status, &ffo->ffo);
+ }
+ #endif

--- a/utils/utilities.sh
+++ b/utils/utilities.sh
@@ -116,6 +116,47 @@ verify_checksum() {
     fi
 }
 
+############################################################################
+# @Brief    : Fail if any matching DKMS module did not build/install for the
+#             running kernel. Some vendor packages mask DKMS build failures in
+#             their package scripts, so check immediately after installation.
+#
+# @Args     : DKMS module names to check (e.g. "mlnx-ofa_kernel").
+############################################################################
+check_dkms_status() {
+    command -v dkms >/dev/null 2>&1 || return 0
+
+    local kernel_version=$(uname -r)
+    local module status found failed
+    local log_file
+
+    for module in "$@"; do
+        found=0
+        failed=0
+        while IFS= read -r status; do
+            found=1
+            echo "${status}"
+            if ! grep -q "${kernel_version}.*: installed" <<< "${status}"; then
+                failed=1
+            fi
+        done < <(dkms status -m "${module}" 2>/dev/null || true)
+
+        if [[ ${found} -eq 0 ]]; then
+            echo "ERROR: DKMS module ${module} has no status entry" >&2
+            exit 1
+        fi
+        if [[ ${failed} -ne 0 ]]; then
+            echo "ERROR: DKMS module ${module} is not installed for ${kernel_version}" >&2
+            for log_file in /var/lib/dkms/${module}/*/build/make.log; do
+                [[ -f "${log_file}" ]] || continue
+                echo "--- ${log_file} ---" >&2
+                tail -n 80 "${log_file}" >&2 || true
+            done
+            exit 1
+        fi
+    done
+}
+
 # Private helper that matches NCv6.
 function _is_ncv6_sku {
     case "$SKU" in

--- a/utils/utilities.sh
+++ b/utils/utilities.sh
@@ -127,17 +127,17 @@ check_dkms_status() {
     command -v dkms >/dev/null 2>&1 || return 0
 
     local kernel_version=$(uname -r)
-    local module status found failed
+    local module status found current_installed
     local log_file
 
     for module in "$@"; do
         found=0
-        failed=0
+        current_installed=0
         while IFS= read -r status; do
             found=1
             echo "${status}"
-            if ! grep -q "${kernel_version}.*: installed" <<< "${status}"; then
-                failed=1
+            if grep -q "${kernel_version}.*: installed" <<< "${status}"; then
+                current_installed=1
             fi
         done < <(dkms status -m "${module}" 2>/dev/null || true)
 
@@ -145,7 +145,7 @@ check_dkms_status() {
             echo "ERROR: DKMS module ${module} has no status entry" >&2
             exit 1
         fi
-        if [[ ${failed} -ne 0 ]]; then
+        if [[ ${current_installed} -ne 1 ]]; then
             echo "ERROR: DKMS module ${module} is not installed for ${kernel_version}" >&2
             for log_file in /var/lib/dkms/${module}/*/build/make.log; do
                 [[ -f "${log_file}" ]] || continue


### PR DESCRIPTION
DOCA-OFED kmod fails to install on RHEL family due to kernel API change and needs DKMS patching
Lustre on Azure has no IB line-of-sight, so disabling o2ib to avoid compilation errors