### PR TITLE
Restore and harden lustre check

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -56,8 +56,7 @@ function test_component {
         check_aocc) verify_aocc_installation;;
         check_docker) verify_docker_installation;;
         check_dcgm) verify_dcgm_installation;;
-        # only best-effort install since Lustre isn't always available
-        # check_lustre) verify_lustre_installation;;
+        check_lustre) verify_lustre_installation;;
         check_nvlink) verify_nvlink_setup;;
         check_nvbandwidth) verify_nvbandwidth_setup;;
         check_nvloom) verify_nvloom_setup;;

--- a/tests/test-definitions.sh
+++ b/tests/test-definitions.sh
@@ -455,16 +455,20 @@ function verify_ib_modules_and_devices {
     fi
 }
 
-# only best-effort install since Lustre isn't always available
-# function verify_lustre_installation {
-#     case ${ID} in
-#         ubuntu) dpkg -l | grep lustre-client;;
-#         almalinux|rocky|rhel) dnf list installed | grep lustre-client;;
-#         azurelinux) true;;
-#         * ) ;;
-#     esac
-#     check_exit_code "Lustre Installed" "Lustre not installed!"
-# }
+function verify_lustre_installation {
+    # Verify both halves of a usable Lustre client: the userspace utilities and
+    # the kernel module for the running kernel (modinfo catches a silently-failed
+    # DKMS build, where the package installs but no module is built).
+    command -v lctl > /dev/null 2>&1
+    check_exit_code "Lustre userspace client (lctl) is present" "Lustre userspace client (lctl) not found!"
+
+    if modinfo lustre > /dev/null 2>&1; then
+        echo "[OK] : Lustre client kernel module (lustre.ko) is present"
+    else
+        echo "*** verify_lustre_installation: Error - no loadable Lustre client kernel module (lustre.ko) for running kernel $(uname -r); DKMS build likely failed (dkms status shows it 'added', not 'installed' for this kernel)" >&2
+        exit_on_error
+    fi
+}
 
 function verify_gdrcopy_installation {
     # Verify GDRCopy package installation


### PR DESCRIPTION
The Lustre functional check was disabled in the past to not block experimental and/or builds on brand new kernels that cannot install Lustre, but this check is necessary as a correctness gate and needs to be restored. In addition to checking the lustre client, verify the kernel module is listed as well