### PR TITLE
Update upstream lustre for U24 for tr() patch

### DIFF
--- a/components/install_lustre_client.sh
+++ b/components/install_lustre_client.sh
@@ -78,16 +78,8 @@ configure_lustre_dkms_no_o2ib_with_tr_workaround() {
     mkdir -p "$(dirname "${config_file}")"
     cat > "${config_file}" <<'EOF'
 # Azure clients do not have IB line of sight to Lustre servers, so use TCP LNet.
-# TODO: Drop the tr() workaround after AMLFS publishes Lustre DKMS with LU-19792.
 OPTS=$(printf '%s\n' "${OPTS:-}" | sed -E 's#(^|[[:space:]])--with-o2ib=[^[:space:]]+##g')
 LUSTRE_DKMS_CONFIGURE_EXTRA="--with-o2ib=no"
-tr() {
-    if [[ $# -eq 2 && "$1" == " " && ( "$2" == "\\n" || "$2" == "\\\\n" ) ]]; then
-        command tr ' ' '\n'
-    else
-        command tr "$@"
-    fi
-}
 EOF
 }
 

--- a/components/install_lustre_client.sh
+++ b/components/install_lustre_client.sh
@@ -78,7 +78,6 @@ configure_lustre_dkms_no_o2ib_with_tr_workaround() {
     mkdir -p "$(dirname "${config_file}")"
     cat > "${config_file}" <<'EOF'
 # Azure clients do not have IB line of sight to Lustre servers, so use TCP LNet.
-OPTS=$(printf '%s\n' "${OPTS:-}" | sed -E 's#(^|[[:space:]])--with-o2ib=[^[:space:]]+##g')
 LUSTRE_DKMS_CONFIGURE_EXTRA="--with-o2ib=no"
 EOF
 }

--- a/versions.json
+++ b/versions.json
@@ -1005,10 +1005,10 @@
         },
         "ubuntu24.04": {
             "aarch64": {
-                "version": "2.17.0-19-gbb5310f"
+                "version": "2.17.0-22-gcc77e37"
             },
             "x86_64": {
-                "version": "2.17.0-19-gbb5310f"
+                "version": "2.17.0-22-gcc77e37"
             }
         },
         "rocky8.10": {


### PR DESCRIPTION
a refreshed Ubuntu (Noble/24.04) Lustre client DKMS package is now published. It's based on Lustre 2.17.0 with three targeted fixes on top:
•  --with-o2ib=no  is now honored. A DKMS config bug was silently ignoring the o2ib opt-out, so auto-discovered Mellanox IB still built o2ib. If you're turning off the auto o2ib build, this is the one you want. (LU-19792)
• o2ib path precedence fixed — the OFED/o2ib source path is now selected deterministically. (AB#38618588)
• DKMS build failures now surface instead of being masked. The postinstall previously swallowed build errors ( || true ); it now gates on kernel headers and fails loudly when a build genuinely fails, so a broken module install won't look successful. (AB#38638211)