### PR TITLE
chore: update IMEX to 580.159.04 and remove knem related modules on Azl 3.0

### DIFF
--- a/components/install_mofed.sh
+++ b/components/install_mofed.sh
@@ -28,8 +28,6 @@ if [[ $DISTRIBUTION == "azurelinux3.0" ]]; then
                     mft_kernel-hwe \
                     iser-hwe \
                     isert-hwe \
-                    knem \
-                    knem-hwe-modules \
                     mlnx-nfsrdma-hwe \
                     srp-hwe \
                     xpmem \
@@ -42,8 +40,6 @@ if [[ $DISTRIBUTION == "azurelinux3.0" ]]; then
                     mft_kernel \
                     iser \
                     isert \
-                    knem \
-                    knem-modules \
                     mlnx-nfsrdma \
                     srp \
                     xpmem \
@@ -79,7 +75,6 @@ if [[ $DISTRIBUTION == "azurelinux3.0" ]]; then
                     ucx-ib-mlx5 \
                     ucx-rdmacm \
                     ucx-static \
-                    ucx-knem \
                     ucx-xpmem \
                     libunwind \
                     libunwind-devel

--- a/versions.json
+++ b/versions.json
@@ -449,7 +449,7 @@
         "azurelinux3.0": {
             "aarch64": {
                 "imex": {
-                    "version": "580.105.08"
+                    "version": "580.159.04"
                 }
             }
         }


### PR DESCRIPTION
Along with the recent upgrade of HWE kernel on Azl 3.0 from v6.12 to v6.18, doca-ofed is also upgraded to v3.3.0 to be compatible with kernel-hwe v6.18. knem was deprecated in doca-ofed v3.3.0 and thus, this change updates the script to stop installing knem-related packages.

The NVIDIA GPU driver version was also recently upgraded to 580.159.04 and thus, update the hardcoded IMEX version to be match with the latest GPU driver version.