### PR TITLE
baremetal_3p gb 300 SKU specific nvidia pins

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -358,18 +358,36 @@
         },
         "ubuntu24.04": {
             "x86_64": {
+                "baremetal_3p": {
+                    "nvidia_h100": {
+                        "driver": {
+                            "version": "580.126.20"
+                        }
+                    }
+                },
                 "driver": {
                     "version": "580.167.08"
                 }
             },
             "aarch64": {
                 "baremetal_3p": {
-                    "driver": {
-                        "version": "580.159.04",
-                        "major_version": "580"
+                    "nvidia_gb200": {
+                        "driver": {
+                            "version": "580.159.04",
+                            "major_version": "580"
+                        },
+                        "imex": {
+                            "version": "580.159.04-1"
+                        }
                     },
-                    "imex": {
-                        "version": "580.159.04-1"
+                    "nvidia_gb300": {
+                        "driver": {
+                            "version": "580.126.20",
+                            "major_version": "580"
+                        },
+                        "imex": {
+                            "version": "580.126.20-1"
+                        }
                     }
                 },
                 "driver": {
@@ -803,6 +821,11 @@
         },
         "ubuntu24.04": {
             "x86_64": {
+                "baremetal_3p": {
+                    "nvidia_h100": {
+                        "version": "1:4.5.2-1"
+                    }
+                },
                 "version": "1:4.5.3-1"
             },
             "aarch64": {


### PR DESCRIPTION
## Summary

Add SKU-specific baremetal NVIDIA metadata for GB200, GB300, and H100.

## Why

The new `TARGET_NODE_TYPE=baremetal_3p` lookup groups multiple baremetal image targets under the same node-type path, but these SKUs do not all share the same validated NVIDIA component versions.

GB300 must remain on `580.126.20` because that driver has completed full HCP validation for NScale and Nebius regular GB300 nodes per customer ask. Moving official GB300 ISO production to `580.159.04` before equivalent validation is not intentional.

H100 baremetal also needs to remain aligned with the current H100 offline package manifest and last built image line: NVIDIA driver `580.126.20`, Fabric Manager `580.126.20-1`, and DCGM `1:4.5.2-1`.

## Change

Under `versions.json`:

- `nvidia.ubuntu24.04.aarch64.baremetal_3p.nvidia_gb200`
  - driver `580.159.04`
  - IMEX `580.159.04-1`
- `nvidia.ubuntu24.04.aarch64.baremetal_3p.nvidia_gb300`
  - driver `580.126.20`
  - IMEX `580.126.20-1`
- `nvidia.ubuntu24.04.x86_64.baremetal_3p.nvidia_h100`
  - driver `580.126.20`
- `dcgm.ubuntu24.04.x86_64.baremetal_3p.nvidia_h100`
  - DCGM `1:4.5.2-1`

No nested `baremetal_3p.default` entry is added; unmatched aarch64 baremetal SKUs continue to use the existing arch-level fallback (`580.126.20` / `580.126.20-1`).

## Validation

Verified the metadata resolves to the intended package lines for GB200, GB300, and H100, and confirmed the current Azure-Dedicated-Images H100 manifest remains aligned with azhpc metadata.
