### PR TITLE
Update lustre to fix incompatibility bug + broken dectection

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -933,10 +933,10 @@
         },
         "ubuntu24.04": {
             "aarch64": {
-                "version": "2.17.0-22-gcc77e37"
+                "version": "2.17.0-24-gf517bc4"
             },
             "x86_64": {
-                "version": "2.17.0-22-gcc77e37"
+                "version": "2.17.0-24-gf517bc4"
             }
         },
         "rocky8.10": {


### PR DESCRIPTION
The bug is an incompatibility between the client and server wrt to Hybrid IO being enabled in 2.17. 

 The detection mechanism is broken in 2.17 which could lead to hung writes from the client in certain situations.
 
 https://jira.whamcloud.com/browse/LU-18033