### PR TITLE
fix(temp): workaround nvidia-modprobe file conflict on azl3.0

### DIFF
--- a/components/install_nvidiagpudriver.sh
+++ b/components/install_nvidiagpudriver.sh
@@ -193,7 +193,20 @@ else
     IMEX_VERSION=$(jq -r '.version' <<< $nvidia_imex_metadata)
 
     if [[ $DISTRIBUTION == "azurelinux3.0" ]]; then
-        tdnf install -y nvidia-imex-${IMEX_VERSION}
+        # The aarch64 (GB200/GB300) GPU driver is PMC's 'cuda-open-hwe', which
+        # bundles /usr/bin/nvidia-modprobe (and its man page) but does NOT
+        # declare 'Provides: nvidia-modprobe'. nvidia-imex has
+        # 'Requires: nvidia-modprobe = <ver>', so tdnf pulls the standalone
+        # nvidia-modprobe package from the CUDA repo, whose files then collide
+        # with cuda-open-hwe's bundled copy and abort the rpm transaction
+        # ("conflicts with file from package cuda-open-hwe"). Download imex plus
+        # its nvidia-modprobe dependency and install with rpm --replacefiles so
+        # the identical standalone nvidia-modprobe file cleanly overwrites the
+        # copy shipped in cuda-open-hwe.
+        imex_download_dir=$(mktemp -d)
+        tdnf install -y --downloadonly --downloaddir="$imex_download_dir" nvidia-imex-${IMEX_VERSION}
+        rpm -Uvh --replacefiles "$imex_download_dir"/*.rpm
+        rm -rf "$imex_download_dir"
     elif [[ $DISTRIBUTION == *"ubuntu"* ]]; then
         apt-get install nvidia-imex -y
     else


### PR DESCRIPTION
<img width="2628" height="1524" alt="image" src="https://github.com/user-attachments/assets/735ee114-04be-4cce-b154-ad556e888c34" />

An issue was recently discovered where nvidia-imex-580.159.04 could not be successfully installed due to a file conflict with the cuda-open-hwe package on Azure Linux 3.0. This was caused by a behavior change in NVIDIA's packaging of IMEX on 580.159.04 compared to the older versions. nvidia-modprobe was onboarded as a runtime dependency of nvidia-imex on 580.159.04, which was not the case for the older versions.

This change is made as a temporary workaround to allow nvidia-imex-580.159.04 by downloading the RPMs and performing local installation while allowing file replacements to bypass file conflicts. 

The ultimate fix needs to be made on the Azure Linux 3.0's packaging of cuda-open-hwe.