### PR TITLE
Switch NCv6 target to GA SKU

### DIFF
--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -629,15 +629,15 @@ locals {
   # Keep target-node compatibility keyed by target VM size, not GPU SKU. Multiple
   # VM sizes can map to the same GPU SKU but still represent different build targets.
   target_vm_size_allowed_node_types = {
-    "Standard_ND40rs_v2"                  = ["azure_vm_regular"]
-    "Standard_ND96asr_v4"                 = ["azure_vm_regular"]
-    "Standard_ND96amsr_A100_v4"           = ["azure_vm_regular"]
-    "Standard_ND96isr_MI300X_v5"          = ["azure_vm_regular"]
-    "Standard_ND128isr_NDR_GB200_v6"      = ["azure_vm_regular", "azure_vm_akshost", "baremetal_3p"]
-    "Standard_ND128isr_VR200_v6"          = ["azure_vm_regular"]
+    "Standard_ND40rs_v2"                    = ["azure_vm_regular"]
+    "Standard_ND96asr_v4"                   = ["azure_vm_regular"]
+    "Standard_ND96amsr_A100_v4"             = ["azure_vm_regular"]
+    "Standard_ND96isr_MI300X_v5"            = ["azure_vm_regular"]
+    "Standard_ND128isr_NDR_GB200_v6"        = ["azure_vm_regular", "azure_vm_akshost", "baremetal_3p"]
+    "Standard_ND128isr_VR200_v6"            = ["azure_vm_regular"]
     "Standard_NC144lds_xl_RTXPRO6000BSE_v6" = ["azure_vm_regular"]
-    "ND144ISR_ETH_GB200_METAL_V6"         = ["baremetal_1p"]
-    "ND144ISR_ETH_VR200_METAL_V6"         = ["baremetal_1p"]
+    "ND144ISR_ETH_GB200_METAL_V6"           = ["baremetal_1p"]
+    "ND144ISR_ETH_VR200_METAL_V6"           = ["baremetal_1p"]
   }
   target_vm_size_allowed_node_types_default = ["azure_vm_regular"]
   target_vm_size_node_types = lookup(local.target_vm_size_allowed_node_types, local.target_vm_size, local.target_vm_size_allowed_node_types_default)

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -138,7 +138,7 @@ locals {
     local.target_vm_size == "Standard_ND96isr_MI300X_v5" ? "MI300X" :
     contains(["Standard_ND128isr_NDR_GB200_v6", "ND144ISR_ETH_GB200_METAL_V6"], local.target_vm_size) ? "GB200" :
     contains(["Standard_ND128isr_VR200_v6", "ND144ISR_ETH_VR200_METAL_V6"], local.target_vm_size) ? "VR200" :
-    local.target_vm_size == "Standard_NC128lds_xl_RTXPRO6000BSE_v6" ? "NCv6" :
+    local.target_vm_size == "Standard_NC144lds_xl_RTXPRO6000BSE_v6" ? "NCv6" :
     "A100"
   )
   gpu_platform = (
@@ -625,7 +625,7 @@ locals {
     "Standard_ND96isr_MI300X_v5"          = ["azure_vm_regular"]
     "Standard_ND128isr_NDR_GB200_v6"      = ["azure_vm_regular", "azure_vm_akshost", "baremetal_3p"]
     "Standard_ND128isr_VR200_v6"          = ["azure_vm_regular"]
-    "Standard_NC128lds_xl_RTXPRO6000BSE_v6" = ["azure_vm_regular"]
+    "Standard_NC144lds_xl_RTXPRO6000BSE_v6" = ["azure_vm_regular"]
     "ND144ISR_ETH_GB200_METAL_V6"         = ["baremetal_1p"]
     "ND144ISR_ETH_VR200_METAL_V6"         = ["baremetal_1p"]
   }


### PR DESCRIPTION
## Summary

- replace the preview `Standard_NC128lds_xl_RTXPRO6000BSE_v6` target with the GA `Standard_NC144lds_xl_RTXPRO6000BSE_v6` SKU
- preserve the existing `NCv6` GPU-family classification and `azure_vm_regular` node-type support

## Validation

- `packer validate -syntax-only packer`
- confirmed no preview SKU references remain and both expected GA mappings are present
- VS Code diagnostics report no errors in `packer/variables.pkr.hcl`

Note: `packer fmt -check` reports unrelated pre-existing formatting differences in `packer/variables.pkr.hcl`; this PR intentionally avoids that formatting churn.