### PR TITLE
Disable dynolog.service to avoid holding gpu profiling conflict

### DIFF
--- a/components/install_dynolog_drl.sh
+++ b/components/install_dynolog_drl.sh
@@ -86,7 +86,10 @@ WantedBy=multi-user.target
 EOF
 
     systemctl daemon-reload
-    systemctl enable dynolog.service
+    # dynolog holds an exclusive GPU profiling context (DCGM_FI_PROF_* fields), which clashes
+    # with dcgm-exporter (one profiling client per GPU at a time). Leave the service installed
+    # but disabled so dcgm-exporter can acquire the profiling context.
+    # systemctl enable dynolog.service
 
     ##########################################################################
     # Build and install dyno-relay-logger

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -92,6 +92,11 @@ function verify_common_components {
         verify_package_updates;
     fi
 
+    # Ensure the exclusive GPU profiling context is actually acquirable and not
+    # held by another client (e.g. dynolog), which would clash with dcgm-exporter.
+    # No-op on images without DCGM (e.g. AMD).
+    verify_gpu_profiling_context_available;
+
     if ! verify_network_components_hook; then
         if [[ "$(sku_network_mode)" == "standard_ib" ]]; then
             verify_ofed_installation;

--- a/tests/test-definitions.sh
+++ b/tests/test-definitions.sh
@@ -525,6 +525,57 @@ function verify_dcgm_installation {
     check_exit_code "NVIDIA DCGM service is active" "NVIDIA DCGM service is inactive/dead!"
 }
 
+# Verify the exclusive GPU profiling context can actually be acquired.
+#
+# GPU hardware profiling is exclusive - only one profiling client per GPU at a
+# time. dynolog is built with the DCGM_FI_PROF_* fields; if it (or any other
+# client) holds that context, dcgm-exporter cannot acquire it and enters
+# CrashLoopBackOff. Rather than only inspecting dynolog's systemd state, this
+# probes the context the same way dcgm-exporter does: it asks the standalone
+# nv-hostengine (nvidia-dcgm.service) to watch a DCGM_FI_PROF_* profiling field.
+# If another client is holding the context exclusively, the watch fails.
+function verify_gpu_profiling_context_available {
+    # Only meaningful on NVIDIA images where DCGM is installed and running.
+    if ! command -v dcgmi &>/dev/null; then
+        echo "dcgmi not present; skipping GPU profiling context check [OK]"
+        return 0
+    fi
+    if ! systemctl is-active --quiet nvidia-dcgm; then
+        echo "nvidia-dcgm inactive; skipping GPU profiling context check [OK]"
+        return 0
+    fi
+
+    # 1001 = DCGM_FI_PROF_GR_ENGINE_ACTIVE, a DCP profiling field that requires
+    # the exclusive profiling context. -c 1 takes a single sample then exits.
+    local prof_field="1001"
+    local out rc
+    out=$(timeout 1m dcgmi dmon -e ${prof_field} -c 1 2>&1)
+    rc=$?
+
+    # GPUs that don't support DCP profiling at all are out of scope for this
+    # clash - treat as a skip rather than a failure.
+    if echo "$out" | grep -qiE "not supported|unsupported|profiling.*disabled"; then
+        echo "GPU profiling (DCP) not supported on this SKU; skipping check [OK]"
+        return 0
+    fi
+
+    # A held/exclusive context surfaces as a non-zero exit or an "in use" style
+    # error from DCGM.
+    if [[ $rc -ne 0 ]] || echo "$out" | grep -qiE "in use|already|could not be completed|resource"; then
+        echo "*** ${FUNCNAME[0]}: Error - could not acquire the GPU profiling context (DCGM field ${prof_field})!" >&2
+        echo "*** Another profiling client is likely holding it exclusively; dcgm-exporter will CrashLoopBackOff." >&2
+        if systemctl is-active --quiet dynolog.service 2>/dev/null; then
+            echo "*** Hint: dynolog.service is active and is the likely holder." >&2
+        fi
+        echo "*** dcgmi output:" >&2
+        echo "$out" >&2
+        exit_on_error
+        return
+    fi
+
+    echo "[OK] : GPU profiling context is available (DCGM field ${prof_field})"
+}
+
 function verify_sku_customization_service {
     # Check if the SKU customization service is active
     # Note: bash =~ is ERE, so use regex instead of glob patterns for matching


### PR DESCRIPTION
dynolog holds an exclusive GPU profiling context (DCGM_FI_PROF_* fields), which clashes with dcgm-exporter (one profiling client per GPU at a time). Leave the service installed but disabled so dcgm-exporter can acquire the profiling context.
Also adding tests to confirm if the GPU profiling context is still being hold.