### PR TITLE
Add option to run extra provision script + skip prerequisites installation

### DIFF
--- a/packer/build.pkr.hcl
+++ b/packer/build.pkr.hcl
@@ -219,7 +219,7 @@ build {
 
   provisioner "shell" {
     name            = "(Refresh mode) Regenerate component_versions.txt from installed packages"
-    except          = (local.refresh_mode && !var.skip_hpc) ? [] : ["azure-arm.hpc"]
+    except          = (local.refresh_mode && !var.skip_hpc && !local.skip_prerequisites) ? [] : ["azure-arm.hpc"]
     execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash '{{ .Path }}'"
     inline          = [
       "cd /home/${local.ssh_username}/azhpc-images/components; bash refresh_component_versions.sh ${local.gpu_platform}",

--- a/packer/build.pkr.hcl
+++ b/packer/build.pkr.hcl
@@ -77,6 +77,7 @@ build {
 
   provisioner "shell" {
     name            = "Install prerequisites (LTS kernel, package updates)"
+    except          = local.disable_dynolog_mode ? ["azure-arm.hpc"] : []
     script          = "scripts/prerequisites.sh"
     execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash '{{ .Path }}'"
     environment_vars = [
@@ -127,7 +128,7 @@ build {
 // Placeholder, will check whether VR200 really needs internal bits
   provisioner "shell-local" {
     name           = "download and extract Azure Linux prebuilts for GB200"
-    except         = (!var.skip_hpc && !local.refresh_mode && local.os_family == "azurelinux" && local.nvlink_rackscale) ? [] : ["azure-arm.hpc"]
+    except         = (!var.skip_hpc && !local.refresh_mode && !local.disable_dynolog_mode && local.os_family == "azurelinux" && local.nvlink_rackscale) ? [] : ["azure-arm.hpc"]
     inline_shebang = var.default_inline_shebang
     inline         = [
         "if [[ -z \"${var.internal_bits_container_name}\" || -z \"${var.internal_bits_blob_name}\" || \"${var.internal_bits_container_name}\" =~ ^[Nn]one$ || \"${var.internal_bits_blob_name}\" =~ ^[Nn]one$ ]]; then echo 'Skipping internal bits download: INTERNAL_BITS_CONTAINER_NAME or INTERNAL_BITS_BLOB_NAME is unset/None'; exit 0; fi",
@@ -140,7 +141,7 @@ build {
 // Placeholder, will check whether VR200 really needs internal bits
   provisioner "shell-local" {
     name           = "(1P specific) download and extract GB200 prebuilts"
-    except         = (var.enable_first_party_specifics && !var.skip_hpc && !local.refresh_mode && local.os_family == "ubuntu" && local.distro_version == "24.04" && local.nvlink_rackscale ) ? [] : ["azure-arm.hpc"]
+    except         = (var.enable_first_party_specifics && !var.skip_hpc && !local.refresh_mode && !local.disable_dynolog_mode && local.os_family == "ubuntu" && local.distro_version == "24.04" && local.nvlink_rackscale ) ? [] : ["azure-arm.hpc"]
     inline_shebang = var.default_inline_shebang
     inline         = [
       "if [[ -z \"${var.internal_bits_container_name}\" || -z \"${var.internal_bits_blob_name}\" || \"${var.internal_bits_container_name}\" =~ ^[Nn]one$ || \"${var.internal_bits_blob_name}\" =~ ^[Nn]one$ ]]; then echo 'Skipping internal bits download: INTERNAL_BITS_CONTAINER_NAME or INTERNAL_BITS_BLOB_NAME is unset/None'; exit 0; fi",
@@ -180,7 +181,7 @@ build {
 
   provisioner "shell" {
     name              = "Reboot"
-    except            = (var.skip_hpc || local.refresh_mode) ? ["azure-arm.hpc"] : []
+    except            = (var.skip_hpc || local.refresh_mode || local.disable_dynolog_mode) ? ["azure-arm.hpc"] : []
     inline_shebang    = var.default_inline_shebang
     skip_clean        = true
     expect_disconnect = true
@@ -192,7 +193,7 @@ build {
 
   provisioner "shell" {
     name            = "Install HPC components"
-    except          = (var.skip_hpc || local.refresh_mode) ? ["azure-arm.hpc"] : []
+    except          = (var.skip_hpc || local.refresh_mode || local.disable_dynolog_mode) ? ["azure-arm.hpc"] : []
     execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash '{{ .Path }}'"
     environment_vars = [
     "TARGET_NODE_TYPE=${local.target_node_type}",
@@ -206,7 +207,7 @@ build {
 
   provisioner "shell" {
     name              = "Reboot"
-    except            = (var.skip_hpc || local.refresh_mode) ? ["azure-arm.hpc"] : []
+    except            = (var.skip_hpc || local.refresh_mode || local.disable_dynolog_mode) ? ["azure-arm.hpc"] : []
     inline_shebang    = var.default_inline_shebang
     skip_clean        = true
     expect_disconnect = true
@@ -222,6 +223,42 @@ build {
     execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash '{{ .Path }}'"
     inline          = [
       "cd /home/${local.ssh_username}/azhpc-images/components; bash refresh_component_versions.sh ${local.gpu_platform}",
+    ]
+  }
+
+  provisioner "shell" {
+    name           = "(Disable dynolog mode) Stop and disable dynolog services"
+    except         = local.disable_dynolog_mode ? [] : ["azure-arm.hpc"]
+    inline_shebang = var.default_inline_shebang
+    inline = [
+      "for svc in dynolog.service dyno-relay-logger.service; do",
+      "  if systemctl list-unit-files --no-legend \"$svc\" 2>/dev/null | grep -q .; then",
+      "    echo \"Stopping and disabling $svc\"",
+      "    sudo systemctl stop \"$svc\" || true",
+      "    sudo systemctl disable \"$svc\" || true",
+      "  else",
+      "    echo \"$svc not installed; skipping\"",
+      "  fi",
+      "done",
+      "sudo systemctl daemon-reload",
+    ]
+  }
+
+  provisioner "shell" {
+    name            = "(Published-image base) Refresh test definitions from latest repo"
+    except          = local.base_from_published_image ? [] : ["azure-arm.hpc"]
+    execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash '{{ .Path }}'"
+    environment_vars = [
+      "AZHPC_IMAGES_TEST_DIR=/home/${local.ssh_username}/azhpc-images/tests",
+    ]
+    # In-place refresh and disable-dynolog modes boot from a published base image
+    # that may carry stale tests under /opt/azurehpc/test. Re-run the canonical
+    # copy so the run-tests step uses the latest definitions. Remove the existing
+    # health_checks dir first so copy_test_file.sh's `cp -r` replaces it cleanly
+    # instead of nesting into the pre-existing directory.
+    inline = [
+      "sudo rm -rf /opt/azurehpc/test/health_checks",
+      "bash /home/${local.ssh_username}/azhpc-images/components/copy_test_file.sh",
     ]
   }
 

--- a/packer/build.pkr.hcl
+++ b/packer/build.pkr.hcl
@@ -279,7 +279,7 @@ build {
 
   provisioner "shell" {
     name            = "Trivy vulnerability scanning (standalone step for testing purposes)"
-    except          = var.skip_hpc ? [] : ["azure-arm.hpc"]
+    except          = (var.skip_hpc || local.refresh_mode) ? [] : ["azure-arm.hpc"]
     execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash '{{ .Path }}'"
     inline          = [
       "cd /home/${local.ssh_username}/azhpc-images/distros/${local.os_script_folder_name}/; ARCHITECTURE=$(uname -m) bash ../../components/trivy_scan.sh",

--- a/packer/build.pkr.hcl
+++ b/packer/build.pkr.hcl
@@ -77,7 +77,7 @@ build {
 
   provisioner "shell" {
     name            = "Install prerequisites (LTS kernel, package updates)"
-    except          = local.disable_dynolog_mode ? ["azure-arm.hpc"] : []
+    except          = local.skip_prerequisites ? ["azure-arm.hpc"] : []
     script          = "scripts/prerequisites.sh"
     execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash '{{ .Path }}'"
     environment_vars = [
@@ -128,7 +128,7 @@ build {
 // Placeholder, will check whether VR200 really needs internal bits
   provisioner "shell-local" {
     name           = "download and extract Azure Linux prebuilts for GB200"
-    except         = (!var.skip_hpc && !local.refresh_mode && !local.disable_dynolog_mode && local.os_family == "azurelinux" && local.nvlink_rackscale) ? [] : ["azure-arm.hpc"]
+    except         = (!var.skip_hpc && !local.refresh_mode && local.os_family == "azurelinux" && local.nvlink_rackscale) ? [] : ["azure-arm.hpc"]
     inline_shebang = var.default_inline_shebang
     inline         = [
         "if [[ -z \"${var.internal_bits_container_name}\" || -z \"${var.internal_bits_blob_name}\" || \"${var.internal_bits_container_name}\" =~ ^[Nn]one$ || \"${var.internal_bits_blob_name}\" =~ ^[Nn]one$ ]]; then echo 'Skipping internal bits download: INTERNAL_BITS_CONTAINER_NAME or INTERNAL_BITS_BLOB_NAME is unset/None'; exit 0; fi",
@@ -141,7 +141,7 @@ build {
 // Placeholder, will check whether VR200 really needs internal bits
   provisioner "shell-local" {
     name           = "(1P specific) download and extract GB200 prebuilts"
-    except         = (var.enable_first_party_specifics && !var.skip_hpc && !local.refresh_mode && !local.disable_dynolog_mode && local.os_family == "ubuntu" && local.distro_version == "24.04" && local.nvlink_rackscale ) ? [] : ["azure-arm.hpc"]
+    except         = (var.enable_first_party_specifics && !var.skip_hpc && !local.refresh_mode && local.os_family == "ubuntu" && local.distro_version == "24.04" && local.nvlink_rackscale ) ? [] : ["azure-arm.hpc"]
     inline_shebang = var.default_inline_shebang
     inline         = [
       "if [[ -z \"${var.internal_bits_container_name}\" || -z \"${var.internal_bits_blob_name}\" || \"${var.internal_bits_container_name}\" =~ ^[Nn]one$ || \"${var.internal_bits_blob_name}\" =~ ^[Nn]one$ ]]; then echo 'Skipping internal bits download: INTERNAL_BITS_CONTAINER_NAME or INTERNAL_BITS_BLOB_NAME is unset/None'; exit 0; fi",
@@ -181,7 +181,7 @@ build {
 
   provisioner "shell" {
     name              = "Reboot"
-    except            = (var.skip_hpc || local.refresh_mode || local.disable_dynolog_mode) ? ["azure-arm.hpc"] : []
+    except            = (var.skip_hpc || local.refresh_mode) ? ["azure-arm.hpc"] : []
     inline_shebang    = var.default_inline_shebang
     skip_clean        = true
     expect_disconnect = true
@@ -193,7 +193,7 @@ build {
 
   provisioner "shell" {
     name            = "Install HPC components"
-    except          = (var.skip_hpc || local.refresh_mode || local.disable_dynolog_mode) ? ["azure-arm.hpc"] : []
+    except          = (var.skip_hpc || local.refresh_mode) ? ["azure-arm.hpc"] : []
     execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash '{{ .Path }}'"
     environment_vars = [
     "TARGET_NODE_TYPE=${local.target_node_type}",
@@ -207,7 +207,7 @@ build {
 
   provisioner "shell" {
     name              = "Reboot"
-    except            = (var.skip_hpc || local.refresh_mode || local.disable_dynolog_mode) ? ["azure-arm.hpc"] : []
+    except            = (var.skip_hpc || local.refresh_mode) ? ["azure-arm.hpc"] : []
     inline_shebang    = var.default_inline_shebang
     skip_clean        = true
     expect_disconnect = true
@@ -227,35 +227,40 @@ build {
   }
 
   provisioner "shell" {
-    name           = "(Disable dynolog mode) Stop and disable dynolog services"
-    except         = local.disable_dynolog_mode ? [] : ["azure-arm.hpc"]
-    inline_shebang = var.default_inline_shebang
+    name            = "Run extra fix-up script"
+    except          = local.run_extra_provision_script ? [] : ["azure-arm.hpc"]
+    execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash '{{ .Path }}'"
+    environment_vars = [
+      "GPU=${local.gpu_platform}",
+      "GPU_SKU=${local.gpu_sku}",
+      "TARGET_NODE_TYPE=${local.target_node_type}",
+      "REFRESH_MODE=${local.refresh_mode}",
+    ]
+    # Generic hook for one-off in-place-refresh fix-ups (e.g. disabling a
+    # service). The specific script is provided via extra_provision_script and
+    # should live on a temporary branch, not on main.
     inline = [
-      "for svc in dynolog.service dyno-relay-logger.service; do",
-      "  if systemctl list-unit-files --no-legend \"$svc\" 2>/dev/null | grep -q .; then",
-      "    echo \"Stopping and disabling $svc\"",
-      "    sudo systemctl stop \"$svc\" || true",
-      "    sudo systemctl disable \"$svc\" || true",
-      "  else",
-      "    echo \"$svc not installed; skipping\"",
-      "  fi",
-      "done",
-      "sudo systemctl daemon-reload",
+      "REPO_DIR=/home/${local.ssh_username}/azhpc-images",
+      "SCRIPT='${local.extra_provision_script}'",
+      "case \"$SCRIPT\" in /*) SCRIPT_PATH=\"$SCRIPT\";; *) SCRIPT_PATH=\"$REPO_DIR/$SCRIPT\";; esac",
+      "echo \"Running extra fix-up script: $SCRIPT_PATH\"",
+      "if [[ ! -f \"$SCRIPT_PATH\" ]]; then echo \"ERROR: extra provisioning script not found: $SCRIPT_PATH\"; exit 1; fi",
+      "bash \"$SCRIPT_PATH\"",
     ]
   }
 
   provisioner "shell" {
-    name            = "(Published-image base) Refresh test definitions from latest repo"
-    except          = local.base_from_published_image ? [] : ["azure-arm.hpc"]
+    name            = "(In-place refresh) Refresh test definitions from latest repo"
+    except          = local.refresh_mode ? [] : ["azure-arm.hpc"]
     execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash '{{ .Path }}'"
     environment_vars = [
       "AZHPC_IMAGES_TEST_DIR=/home/${local.ssh_username}/azhpc-images/tests",
     ]
-    # In-place refresh and disable-dynolog modes boot from a published base image
-    # that may carry stale tests under /opt/azurehpc/test. Re-run the canonical
-    # copy so the run-tests step uses the latest definitions. Remove the existing
-    # health_checks dir first so copy_test_file.sh's `cp -r` replaces it cleanly
-    # instead of nesting into the pre-existing directory.
+    # In-place refresh boots from a published base image that may carry stale
+    # tests under /opt/azurehpc/test. Re-run the canonical copy so the run-tests
+    # step uses the latest definitions. Remove the existing health_checks dir
+    # first so copy_test_file.sh's `cp -r` replaces it cleanly instead of nesting
+    # into the pre-existing directory.
     inline = [
       "sudo rm -rf /opt/azurehpc/test/health_checks",
       "bash /home/${local.ssh_username}/azhpc-images/components/copy_test_file.sh",

--- a/packer/source.pkr.hcl
+++ b/packer/source.pkr.hcl
@@ -61,14 +61,14 @@ source "azure-arm" "hpc" {
     }
   }
 
-  # Base Marketplace image info (disabled when booting from a published SIG image)
-  image_publisher = local.base_from_published_image ? null : local.image_publisher
-  image_offer     = local.base_from_published_image ? null : local.image_offer
-  image_sku       = local.base_from_published_image ? null : local.image_sku
+  # Base Marketplace image info (disabled in refresh mode — SIG image used instead)
+  image_publisher = local.refresh_mode ? null : local.image_publisher
+  image_offer     = local.refresh_mode ? null : local.image_offer
+  image_sku       = local.refresh_mode ? null : local.image_sku
 
   # Marketplace plan info (required for images with purchase agreements, e.g. Rocky Linux)
   dynamic "plan_info" {
-    for_each = (!local.base_from_published_image && local.has_plan_info) ? [local.builtin_marketplace_plan_info[local.os_family]] : []
+    for_each = (!local.refresh_mode && local.has_plan_info) ? [local.builtin_marketplace_plan_info[local.os_family]] : []
     content {
       plan_name      = plan_info.value.plan_name
       plan_product   = plan_info.value.plan_product
@@ -76,19 +76,18 @@ source "azure-arm" "hpc" {
     }
   }
 
-  # Base image from Shared Image Gallery (refresh/disable-dynolog mode or direct shared gallery)
+  # Base image from Shared Image Gallery (refresh mode or direct shared gallery)
   dynamic "shared_image_gallery" {
-    for_each = local.base_from_published_image ? [1] : (local.direct_shared_gallery_image_id != null && local.direct_shared_gallery_image_id != "") ? [1] : []
+    for_each = local.refresh_mode ? [1] : (local.direct_shared_gallery_image_id != null && local.direct_shared_gallery_image_id != "") ? [1] : []
     content {
-      # When booting from a published image, use the specified previous HPC image
-      # version from SIG. Otherwise, use the direct shared gallery image (e.g. 1P
-      # Azure Linux images).
-      image_name                     = local.base_from_published_image ? local.refresh_sig_image_name : null
-      gallery_name                   = local.base_from_published_image ? local.refresh_sig_gallery_name : null
-      image_version                  = local.base_from_published_image ? local.refresh_sig_image_version : null
-      resource_group                 = local.base_from_published_image ? local.refresh_sig_resource_group : null
-      subscription                   = local.base_from_published_image ? local.refresh_sig_subscription : null
-      direct_shared_gallery_image_id = local.base_from_published_image ? null : local.direct_shared_gallery_image_id
+      # In refresh mode, use the specified previous HPC image version from SIG
+      # Otherwise, use the direct shared gallery image (e.g. 1P Azure Linux images)
+      image_name                     = local.refresh_mode ? local.refresh_sig_image_name : null
+      gallery_name                   = local.refresh_mode ? local.refresh_sig_gallery_name : null
+      image_version                  = local.refresh_mode ? local.refresh_sig_image_version : null
+      resource_group                 = local.refresh_mode ? local.refresh_sig_resource_group : null
+      subscription                   = local.refresh_mode ? local.refresh_sig_subscription : null
+      direct_shared_gallery_image_id = local.refresh_mode ? null : local.direct_shared_gallery_image_id
     }
   }
 

--- a/packer/source.pkr.hcl
+++ b/packer/source.pkr.hcl
@@ -61,14 +61,14 @@ source "azure-arm" "hpc" {
     }
   }
 
-  # Base Marketplace image info (disabled in refresh mode — SIG image used instead)
-  image_publisher = local.refresh_mode ? null : local.image_publisher
-  image_offer     = local.refresh_mode ? null : local.image_offer
-  image_sku       = local.refresh_mode ? null : local.image_sku
+  # Base Marketplace image info (disabled when booting from a published SIG image)
+  image_publisher = local.base_from_published_image ? null : local.image_publisher
+  image_offer     = local.base_from_published_image ? null : local.image_offer
+  image_sku       = local.base_from_published_image ? null : local.image_sku
 
   # Marketplace plan info (required for images with purchase agreements, e.g. Rocky Linux)
   dynamic "plan_info" {
-    for_each = (!local.refresh_mode && local.has_plan_info) ? [local.builtin_marketplace_plan_info[local.os_family]] : []
+    for_each = (!local.base_from_published_image && local.has_plan_info) ? [local.builtin_marketplace_plan_info[local.os_family]] : []
     content {
       plan_name      = plan_info.value.plan_name
       plan_product   = plan_info.value.plan_product
@@ -76,18 +76,19 @@ source "azure-arm" "hpc" {
     }
   }
 
-  # Base image from Shared Image Gallery (refresh mode or direct shared gallery)
+  # Base image from Shared Image Gallery (refresh/disable-dynolog mode or direct shared gallery)
   dynamic "shared_image_gallery" {
-    for_each = local.refresh_mode ? [1] : (local.direct_shared_gallery_image_id != null && local.direct_shared_gallery_image_id != "") ? [1] : []
+    for_each = local.base_from_published_image ? [1] : (local.direct_shared_gallery_image_id != null && local.direct_shared_gallery_image_id != "") ? [1] : []
     content {
-      # In refresh mode, use the specified previous HPC image version from SIG
-      # Otherwise, use the direct shared gallery image (e.g. 1P Azure Linux images)
-      image_name                     = local.refresh_mode ? local.refresh_sig_image_name : null
-      gallery_name                   = local.refresh_mode ? local.refresh_sig_gallery_name : null
-      image_version                  = local.refresh_mode ? local.refresh_sig_image_version : null
-      resource_group                 = local.refresh_mode ? local.refresh_sig_resource_group : null
-      subscription                   = local.refresh_mode ? local.refresh_sig_subscription : null
-      direct_shared_gallery_image_id = local.refresh_mode ? null : local.direct_shared_gallery_image_id
+      # When booting from a published image, use the specified previous HPC image
+      # version from SIG. Otherwise, use the direct shared gallery image (e.g. 1P
+      # Azure Linux images).
+      image_name                     = local.base_from_published_image ? local.refresh_sig_image_name : null
+      gallery_name                   = local.base_from_published_image ? local.refresh_sig_gallery_name : null
+      image_version                  = local.base_from_published_image ? local.refresh_sig_image_version : null
+      resource_group                 = local.base_from_published_image ? local.refresh_sig_resource_group : null
+      subscription                   = local.base_from_published_image ? local.refresh_sig_subscription : null
+      direct_shared_gallery_image_id = local.base_from_published_image ? null : local.direct_shared_gallery_image_id
     }
   }
 

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -358,6 +358,25 @@ locals {
   refresh_mode = try(convert(lower(var.refresh_mode), bool), false)
 }
 
+# When disable_dynolog_mode is enabled, a previously published HPC image (from
+# SIG) is used as the base. No HPC components are (re)installed; the only change
+# is that the dynolog services are stopped and disabled so they no longer hold
+# the exclusive GPU profiling context. Tests (including the GPU profiling
+# context check) then run to confirm the context is free before a new image is
+# produced.
+variable "disable_dynolog_mode" {
+  type        = string
+  description = "Boot from a published HPC image, disable the dynolog services, run tests, and output a new image without reinstalling HPC components"
+  default     = env("DISABLE_DYNOLOG_MODE")
+}
+locals {
+  disable_dynolog_mode = try(convert(lower(var.disable_dynolog_mode), bool), false)
+
+  # Modes that boot from a previously published SIG image instead of a
+  # marketplace image. Both reuse the refresh_base_image_id/version plumbing.
+  base_from_published_image = local.refresh_mode || local.disable_dynolog_mode
+}
+
 variable "refresh_base_image_id" {
   type        = string
   description = "Full SIG image version resource ID to use as base for refresh builds (e.g., /subscriptions/.../galleries/.../images/.../versions/...)"
@@ -378,17 +397,17 @@ locals {
   )
 
   # Validate that a base image is specified when refresh mode is enabled
-  _refresh_id_valid = !local.refresh_mode || local.refresh_base_image_id != "not-set"
-  _refresh_id_check = local._refresh_id_valid ? true : file("ERROR: refresh_mode is enabled but neither refresh_base_image_id nor refresh_base_image_version was provided")
+  _refresh_id_valid = !local.base_from_published_image || local.refresh_base_image_id != "not-set"
+  _refresh_id_check = local._refresh_id_valid ? true : file("ERROR: refresh_mode/disable_dynolog_mode is enabled but neither refresh_base_image_id nor refresh_base_image_version was provided")
 
   # Parse the SIG image ID into components for the shared_image_gallery source block
   # Format: /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Compute/galleries/{gallery}/images/{image}/versions/{version}
-  _refresh_id_parts          = local.refresh_mode ? split("/", local.refresh_base_image_id) : []
-  refresh_sig_subscription   = local.refresh_mode ? local._refresh_id_parts[2] : ""
-  refresh_sig_resource_group = local.refresh_mode ? local._refresh_id_parts[4] : ""
-  refresh_sig_gallery_name   = local.refresh_mode ? local._refresh_id_parts[8] : ""
-  refresh_sig_image_name     = local.refresh_mode ? local._refresh_id_parts[10] : ""
-  refresh_sig_image_version  = local.refresh_mode ? local._refresh_id_parts[12] : ""
+  _refresh_id_parts          = local.base_from_published_image ? split("/", local.refresh_base_image_id) : []
+  refresh_sig_subscription   = local.base_from_published_image ? local._refresh_id_parts[2] : ""
+  refresh_sig_resource_group = local.base_from_published_image ? local._refresh_id_parts[4] : ""
+  refresh_sig_gallery_name   = local.base_from_published_image ? local._refresh_id_parts[8] : ""
+  refresh_sig_image_name     = local.base_from_published_image ? local._refresh_id_parts[10] : ""
+  refresh_sig_image_version  = local.base_from_published_image ? local._refresh_id_parts[12] : ""
 }
 
 # =============================================================================

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -358,23 +358,32 @@ locals {
   refresh_mode = try(convert(lower(var.refresh_mode), bool), false)
 }
 
-# When disable_dynolog_mode is enabled, a previously published HPC image (from
-# SIG) is used as the base. No HPC components are (re)installed; the only change
-# is that the dynolog services are stopped and disabled so they no longer hold
-# the exclusive GPU profiling context. Tests (including the GPU profiling
-# context check) then run to confirm the context is free before a new image is
-# produced.
-variable "disable_dynolog_mode" {
+# Generic fix-up hook. When set, Packer runs an extra script on the build VM
+# after the (possibly skipped) component provisioning and before the final
+# tests. This is intended for one-off in-place-refresh fix-ups (e.g. disabling a
+# service) without hardcoding the specific fix into the build definition. Only
+# this generic mechanism lives on main; the specific fix-up scripts it runs
+# should live on temporary branches so they don't accumulate in the repo.
+variable "extra_provision_script" {
   type        = string
-  description = "Boot from a published HPC image, disable the dynolog services, run tests, and output a new image without reinstalling HPC components"
-  default     = env("DISABLE_DYNOLOG_MODE")
+  description = "Optional path to an extra fix-up script to run on the build VM. Relative to the azhpc-images repo root (uploaded to the VM) or an absolute path already on the VM. Default: none."
+  default     = env("EXTRA_PROVISION_SCRIPT")
 }
 locals {
-  disable_dynolog_mode = try(convert(lower(var.disable_dynolog_mode), bool), false)
+  extra_provision_script     = var.extra_provision_script == null ? "" : trimspace(var.extra_provision_script)
+  run_extra_provision_script = local.extra_provision_script != ""
+}
 
-  # Modes that boot from a previously published SIG image instead of a
-  # marketplace image. Both reuse the refresh_base_image_id/version plumbing.
-  base_from_published_image = local.refresh_mode || local.disable_dynolog_mode
+# Skip the prerequisites script (LTS kernel install + base package updates).
+# Useful for in-place refresh fix-ups that must not upgrade the kernel or any
+# packages and should only run the extra provision script.
+variable "skip_prerequisites" {
+  type        = string
+  description = "Skip the prerequisites script (LTS kernel install, package updates). Useful for in-place refresh fix-ups that should not upgrade the kernel or packages."
+  default     = env("SKIP_PREREQUISITES")
+}
+locals {
+  skip_prerequisites = try(convert(lower(var.skip_prerequisites), bool), false)
 }
 
 variable "refresh_base_image_id" {
@@ -397,17 +406,17 @@ locals {
   )
 
   # Validate that a base image is specified when refresh mode is enabled
-  _refresh_id_valid = !local.base_from_published_image || local.refresh_base_image_id != "not-set"
-  _refresh_id_check = local._refresh_id_valid ? true : file("ERROR: refresh_mode/disable_dynolog_mode is enabled but neither refresh_base_image_id nor refresh_base_image_version was provided")
+  _refresh_id_valid = !local.refresh_mode || local.refresh_base_image_id != "not-set"
+  _refresh_id_check = local._refresh_id_valid ? true : file("ERROR: refresh_mode is enabled but neither refresh_base_image_id nor refresh_base_image_version was provided")
 
   # Parse the SIG image ID into components for the shared_image_gallery source block
   # Format: /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Compute/galleries/{gallery}/images/{image}/versions/{version}
-  _refresh_id_parts          = local.base_from_published_image ? split("/", local.refresh_base_image_id) : []
-  refresh_sig_subscription   = local.base_from_published_image ? local._refresh_id_parts[2] : ""
-  refresh_sig_resource_group = local.base_from_published_image ? local._refresh_id_parts[4] : ""
-  refresh_sig_gallery_name   = local.base_from_published_image ? local._refresh_id_parts[8] : ""
-  refresh_sig_image_name     = local.base_from_published_image ? local._refresh_id_parts[10] : ""
-  refresh_sig_image_version  = local.base_from_published_image ? local._refresh_id_parts[12] : ""
+  _refresh_id_parts          = local.refresh_mode ? split("/", local.refresh_base_image_id) : []
+  refresh_sig_subscription   = local.refresh_mode ? local._refresh_id_parts[2] : ""
+  refresh_sig_resource_group = local.refresh_mode ? local._refresh_id_parts[4] : ""
+  refresh_sig_gallery_name   = local.refresh_mode ? local._refresh_id_parts[8] : ""
+  refresh_sig_image_name     = local.refresh_mode ? local._refresh_id_parts[10] : ""
+  refresh_sig_image_version  = local.refresh_mode ? local._refresh_id_parts[12] : ""
 }
 
 # =============================================================================


### PR DESCRIPTION
Add option to run extra provision script + skip prerequisites installation. This would be helpful if we are in scenario where we need to run a one time script on a throwaway branch to patch up an already published image.