### PR TITLE
Enable NVreg_GrdmaPciTopoCheckOverride=1 for baremetal_3p

### DIFF
--- a/components/install_nvidiagpudriver.sh
+++ b/components/install_nvidiagpudriver.sh
@@ -128,7 +128,7 @@ touch /etc/modules-load.d/nvidia-peermem.conf
 echo "nvidia_peermem" >> /etc/modules-load.d/nvidia-peermem.conf
 
 
-if [[ "${TARGET_NODE_TYPE:-azure_vm_regular}" == "baremetal_1p" ]]; then
+if [[ "${TARGET_NODE_TYPE:-azure_vm_regular}" == "baremetal_1p" || "${TARGET_NODE_TYPE:-azure_vm_regular}" == "baremetal_3p" ]]; then
     echo "options nvidia NVreg_GrdmaPciTopoCheckOverride=1" >> /etc/modprobe.d/nvidia.conf
 fi
 


### PR DESCRIPTION
GPUDirect RDMA over dma-buf fails on baremetal_3p clusters because the driver's topology check compares GPU/NIC IOMMU group membership, and native-PCIe HCAs on these clusters land in separate SMMU IOMMU groups from the GPUs, so the check never passes. This mirrors the baremetal_1p override already in place. NVreg_GrdmaPciTopoCheckOverride=1 skips this specific check and has been validated on one of the 3p BM cluster node.