### PR TITLE
Unpin azure packer version

### DIFF
--- a/packer/source.pkr.hcl
+++ b/packer/source.pkr.hcl
@@ -9,7 +9,7 @@ packer {
 
   required_plugins {
     azure = {
-      version = "~> 2.6.0"
+      version = "~> 2.6.3"
       source  = "github.com/hashicorp/azure"
     }
   }

--- a/packer/source.pkr.hcl
+++ b/packer/source.pkr.hcl
@@ -9,9 +9,7 @@ packer {
 
   required_plugins {
     azure = {
-      # Pinned to 2.6.1 as 2.6.2 has a regression on log
-      # throughput
-      version = "2.6.1"
+      version = "~> 2.6.0"
       source  = "github.com/hashicorp/azure"
     }
   }


### PR DESCRIPTION
Updated Azure plugin version constraint to allow 2.6.0 and above since the original bug has been fixed: https://github.com/hashicorp/packer-plugin-azure/issues/633