### PR TITLE
Pin cmake for u22.04 mi300x to avoid no collective device kernels

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -17,6 +17,21 @@
             "url": "https://github.com/Kitware/CMake/releases/download/v4.4.2/cmake-4.4.2-linux-x86_64.tar.gz",
             "sha256": "3ada9a3f5d8a85413579bdd0ea6aa8e8da86efdd6d15c91a1afa517f2021956c"
         },
+        "ubuntu22.04": {
+            "x86_64": {
+                "azure_vm_regular": {
+                    "amd_mi300x": {
+                        "_comment": "CMake 4.4.x makes the RCCL 2.20.5 (rocm-6.2.4) build emit no collective device kernels, so librccl.so links successfully but every ncclAllReduce fails with 'computeCollWorkFunc: unsupported collective'. Keep 4.3.3 until the RCCL source build is fixed.",
+                        "version": "4.3.3",
+                        "url": "https://github.com/Kitware/CMake/releases/download/v4.3.3/cmake-4.3.3-linux-x86_64.tar.gz",
+                        "sha256": "927b2368a946c37269c3a66225ab00544e756459cdd0b5d0da438694fb9ff802"
+                    }
+                },
+                "version": "4.4.2",
+                "url": "https://github.com/Kitware/CMake/releases/download/v4.4.2/cmake-4.4.2-linux-x86_64.tar.gz",
+                "sha256": "3ada9a3f5d8a85413579bdd0ea6aa8e8da86efdd6d15c91a1afa517f2021956c"
+            }
+        },
         "ubuntu24.04": {
             "aarch64": {
                 "baremetal_3p": {


### PR DESCRIPTION
## Pin CMake 4.3.3 for Ubuntu 22.04 MI300X

### Problem

MI300X Ubuntu 22.04 builds fail at RCCL validation. All 8 ranks fail on the first AllReduce:

```
enqueue.cc:1713 NCCL WARN computeCollWorkFunc: unsupported collective.
Test NCCL failure .../all_reduce.cu.cpp:520 'invalid usage'
```

ROCm, RCCL, the source tarball, the cmake arguments, and the test command were all unchanged. The only relevant delta was `versions.json` bumping CMake `4.3.3` → `4.4.2` (`2453a40`).

### Why 4.4.2 breaks it

RCCL 2.20.5 generates its collective device kernels in **pure CMake** (`cmake/Generator.cmake`), using a recursive macro whose loop body pushes and pops a shared accumulator:

```cmake
foreach(item IN LISTS ${current_list})
  list(APPEND ITEM_LIST ${item})
  filter_functions(${FUNCTION_PARAMS} ${new_idx} ${ARGN})
  list(REMOVE_AT ITEM_LIST -1)     # pops the element pushed above
endforeach()
```

Because `filter_functions` is a macro, it is inlined into that loop. At the innermost level it rejects invalid combinations with `continue()`.

CMake 4.4 changed `continue()` inside a macro to genuinely continue the enclosing `foreach`. That now skips the `list(REMOVE_AT ...)` pop on every rejected combination, so the accumulator keeps stale entries and the recursion collapses.

Running RCCL's real generator standalone (`cmake -P`):

| CMake | `FUNC_LIST` | `AllReduce_RING_SIMPLE_Sum.cpp` |
|---|---|---|
| 4.3.3 | 980 | present |
| 4.4.2 | **0** | **absent** |

Nothing errors — `gen_device_table()` faithfully emits `ncclDevFuncTable[] = {nullptr}` and `ncclDevFuncRowToId` entries of `-1`, so `librccl.so` links and installs with an empty collective table. The failure only surfaces at test time when `ncclDevFuncId()` returns `-1`.

Build logs match: 138 → 40 configure-time `Generating` lines, and the only surviving device objects are `common`, `onerank`, and `msccl_kernel_*`.

### Change

Pins CMake `4.3.3` at `cmake.ubuntu22.04.x86_64.azure_vm_regular.amd_mi300x`. `4.4.2` is repeated at the `x86_64` arch level because `get_component_config` falls back to `<distro>.<arch>`; without it, non-MI300X Ubuntu 22.04 builds would resolve to the wrapper object and `.version` would be `null`. Verified: u22/MI300X → 4.3.3, u22/V100 → 4.4.2, all other distros unchanged.

### Not affected

ubuntu24.04 and rocky9.x build RCCL from release/rocm-rel-6.4 (2f7ac66), which has no cmake/Generator.cmake — kernel generation moved to src/device/generate.py, so the defective macro path doesn't exist. almalinux8.10/9.8 are NVIDIA-only and exit early on GPU=AMD, so they never build RCCL. azurelinux3.0 uses packaged RCCL with no source build. (rocky8.10 builds rocm-6.2.2 and has the same defect; out of scope here.)

### Follow-up

Upstream fix for `ROCm/rccl`: replacing the `continue()` with an `if (is_valid) ... endif()` guard makes both CMake versions produce 980.