### PR TITLE
Update GB200 CRD 1.3.10 / GB300 CRD 1.0.10 driver and DCGM versions

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -670,8 +670,8 @@
         "ubuntu24.04": {
             "aarch64": {
                 "baremetal_3p": {
-                    "version": "2.5.1-1",
-                    "commit": "0f7366e73b019e7facf907381f6b0b2f5a1576e4",
+                    "version": "2.5.2-1",
+                    "commit": "c91ad9f178e5fb729fc5b6dc62a77c3bb364d6c9",
                     "distribution": "Ubuntu24_04"
                 },
                 "azure_vm_akshost": {

--- a/versions.json
+++ b/versions.json
@@ -347,20 +347,20 @@
                 "baremetal_3p": {
                     "nvidia_gb200": {
                         "driver": {
-                            "version": "580.159.04",
+                            "version": "580.167.08",
                             "major_version": "580"
                         },
                         "imex": {
-                            "version": "580.159.04-1"
+                            "version": "580.167.08-1"
                         }
                     },
                     "nvidia_gb300": {
                         "driver": {
-                            "version": "580.126.20",
+                            "version": "580.167.08",
                             "major_version": "580"
                         },
                         "imex": {
-                            "version": "580.126.20-1"
+                            "version": "580.167.08-1"
                         }
                     }
                 },
@@ -806,7 +806,7 @@
             },
             "aarch64": {
                 "baremetal_3p": {
-                    "version": "1:4.4.2-1"
+                    "version": "1:4.5.3-1"
                 },
                 "version": "1:4.5.3-1"
             }


### PR DESCRIPTION
- nvidia.ubuntu24.04.aarch64.baremetal_3p: bump nvidia_gb200 and nvidia_gb300 GPU driver + IMEX from 580.159.04/580.126.20 to 580.167.08 (imex 580.167.08-1), matching the validated driver reported in NVIDIA's DGX GB200 NVL72 CRD 1.3.10 and DGX GB300 NVL72 CRD 1.0.10 release notes.
- dcgm.ubuntu24.04.aarch64.baremetal_3p: bump from 1:4.4.2-1 to 1:4.5.3-1 to match the Azure VM (default) aarch64 DCGM version.
- gdrcopy.ubuntu24.04.aarch64.baremetal_3p: bump from 2.5.1-1 to
2.5.2-1 (commit c91ad9f) to match the Azure VM (default) aarch64
GDRCopy version.