### PR TITLE
Harden MDATP cleanup and Ubuntu build reliability

### DIFF
--- a/utils/clear_history.sh
+++ b/utils/clear_history.sh
@@ -77,6 +77,14 @@ same_fs() {
 distro=`find_distro`
 echo "Detected distro: ${distro}"
 
+# Stop extension auto-provisioning before the first mdatp purge. The filesystem
+# cleanup below can take several minutes, which otherwise gives the Azure guest
+# agent enough time to install MDE again before the epilog runs.
+if [[ "${TARGET_NODE_TYPE:-azure_vm_regular}" != "baremetal_1p" ]] && command -v systemctl >/dev/null 2>&1; then
+    systemctl stop walinuxagent.service 2>/dev/null || true
+    systemctl stop waagent.service 2>/dev/null || true
+fi
+
 if [[ $distro == *"AlmaLinux"* ]] || [[ $distro == *"Rocky"* ]] || [[ $distro == *"Red Hat"* ]]
 then
     # Sync dnf and rpmdb after installing RPMs outside dnf.

--- a/utils/clear_history_epilog.sh
+++ b/utils/clear_history_epilog.sh
@@ -62,11 +62,155 @@ find_azurelinux_distro() {
 distro=`find_distro`
 echo "Detected distro: ${distro}"
 
+verify_final_cleanup() {
+    local path
+
+    if [[ ${distro} == *"Ubuntu"* ]] && \
+        dpkg -l 2>/dev/null | grep -qE '^(ii|rc|hi|ri|pi|ip|in)[[:space:]]+(mdatp|microsoft-mdatp)(:|[[:space:]])'; then
+        echo "ERROR: mdatp has a dpkg state before image capture"
+        dpkg -l 2>/dev/null | grep -E '(mdatp|microsoft-mdatp)' || true
+        return 1
+    elif [[ ${distro} != *"Ubuntu"* ]] && {
+        rpm -q mdatp >/dev/null 2>&1 || rpm -q microsoft-mdatp >/dev/null 2>&1
+    }; then
+        echo "ERROR: mdatp package is still present before image capture"
+        return 1
+    fi
+
+    if [[ ${distro} == *"Ubuntu"* ]] && {
+        compgen -G '/var/lib/dpkg/info/mdatp.*' >/dev/null ||
+            compgen -G '/var/lib/dpkg/info/microsoft-mdatp.*' >/dev/null
+    }; then
+        echo "ERROR: mdatp dpkg metadata is still present before image capture"
+        ls -la /var/lib/dpkg/info/mdatp.* /var/lib/dpkg/info/microsoft-mdatp.* 2>/dev/null || true
+        return 1
+    fi
+
+    if command -v mdatp >/dev/null 2>&1; then
+        echo "ERROR: mdatp executable is still present before image capture"
+        return 1
+    fi
+
+    if command -v systemctl >/dev/null 2>&1 && {
+        systemctl cat mdatp.service >/dev/null 2>&1 ||
+            systemctl list-unit-files 2>/dev/null | grep -qw mdatp.service
+    }; then
+        echo "ERROR: mdatp.service is still present before image capture"
+        systemctl status mdatp.service 2>/dev/null || true
+        return 1
+    fi
+
+    if pgrep -x wdavdaemon >/dev/null 2>&1; then
+        echo "ERROR: wdavdaemon is still running before image capture"
+        pgrep -a -x wdavdaemon || true
+        return 1
+    fi
+
+    for path in \
+        /opt/microsoft/mdatp \
+        /opt/microsoft/mde \
+        /var/opt/microsoft/mdatp \
+        /etc/opt/microsoft/mdatp \
+        /etc/opt/microsoft/mdatp_onboard.json \
+        /var/log/microsoft/mdatp \
+        /etc/audit/rules.d/mdatp.rules \
+        /etc/apparmor.d/mdatp \
+        /etc/apparmor.d/disable/mdatp \
+        /usr/lib/systemd/system/mdatp.service \
+        /etc/systemd/system/multi-user.target.wants/mdatp.service \
+        /var/lib/dpkg/info/mdatp.list \
+        /var/lib/dpkg/info/mdatp.md5sums \
+        /var/lib/dpkg/info/mdatp.postinst \
+        /var/lib/dpkg/info/mdatp.postrm \
+        /var/lib/dpkg/info/mdatp.preinst \
+        /var/lib/dpkg/info/mdatp.prerm \
+        /var/lib/dpkg/info/mdatp.conffiles; do
+        if [[ -e ${path} || -L ${path} ]]; then
+            echo "ERROR: MDE path is still present before image capture: ${path}"
+            return 1
+        fi
+    done
+
+    for path in \
+        '/var/lib/waagent/*MDE.Linux*' \
+        '/var/log/azure/*MDE.Linux*' \
+        '/var/lib/GuestConfig/extension_logs/*MDE.Linux*'; do
+        if compgen -G "${path}" >/dev/null; then
+            echo "ERROR: MDE extension residue is still present before image capture: ${path}"
+            return 1
+        fi
+    done
+
+    if find / -xdev -type f \( -name 'eicar.com*' -o -name 'utils_58.py' \) \
+        -not -path '/proc/*' -not -path '/sys/*' -print -quit 2>/dev/null | grep -q .; then
+        echo "ERROR: EICAR test artifact is still present before image capture"
+        return 1
+    fi
+}
+
+# The Azure guest agent can auto-provision MDE again after clear_history.sh has
+# removed it. Stop the agent before the final package cleanup so no extension
+# operation can race image capture.
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl stop walinuxagent.service 2>/dev/null || true
+    systemctl stop waagent.service 2>/dev/null || true
+fi
+
+# Purge mdatp again immediately before image capture. The first purge happens
+# in clear_history.sh, but MDE may have been auto-provisioned again afterwards.
+if [[ ${distro} == *"Ubuntu"* ]]; then
+    if dpkg -l | grep -qw mdatp; then
+        DEBIAN_FRONTEND=noninteractive apt-get purge -y mdatp
+    fi
+elif [[ ${distro} == *"Azure Linux"* ]]; then
+    if rpm -q mdatp >/dev/null 2>&1; then
+        dnf remove -y mdatp
+    fi
+else
+    if rpm -q mdatp >/dev/null 2>&1; then
+        dnf remove -y mdatp
+    fi
+fi
+
 # Remove the AzNHC log
 sudo rm -f /opt/azurehpc/test/azurehpc-health-checks/health.log
 
 # Uninstall the OMS Agent
 wget -qO- https://raw.githubusercontent.com/microsoft/OMS-Agent-for-Linux/master/installer/scripts/uninstall.sh | sudo bash
+
+# Remove both agent data and extension state. These paths are checked by the
+# LISA certification script and must not be baked into the captured image.
+rm -rf \
+    /opt/microsoft/mdatp \
+    /opt/microsoft/mde \
+    /var/opt/microsoft/mdatp \
+    /etc/opt/microsoft/mdatp \
+    /etc/opt/microsoft/mdatp_onboard.json \
+    /var/log/microsoft/mdatp \
+    /etc/audit/rules.d/mdatp.rules \
+    /etc/apparmor.d/mdatp \
+    /etc/apparmor.d/disable/mdatp \
+    /usr/lib/systemd/system/mdatp.service \
+    /etc/systemd/system/multi-user.target.wants/mdatp.service \
+    /var/lib/dpkg/info/mdatp.list \
+    /var/lib/dpkg/info/mdatp.md5sums \
+    /var/lib/dpkg/info/mdatp.postinst \
+    /var/lib/dpkg/info/mdatp.postrm \
+    /var/lib/dpkg/info/mdatp.preinst \
+    /var/lib/dpkg/info/mdatp.prerm \
+    /var/lib/dpkg/info/mdatp.conffiles \
+    /var/lib/waagent/*MDE.Linux* \
+    /var/log/azure/*MDE.Linux* \
+    /var/lib/GuestConfig/extension_logs/*MDE.Linux*
+
+# Remove Defender test artifacts without crossing into mounted data disks.
+find / -xdev -type f \( -name 'eicar.com*' -o -name 'utils_58.py' \) \
+    -not -path '/proc/*' -not -path '/sys/*' -delete 2>/dev/null || true
+
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload
+fi
+verify_final_cleanup
 
 
 # Switch to the root user


### PR DESCRIPTION
## Summary

This PR addresses two image-build issues:

- Hardens Microsoft Defender for Endpoint (MDE/MDATP) cleanup so platform re-provisioning cannot leave Defender residue in the captured image.
- Updates the Ubuntu Dynolog build toolchain to Rust/Cargo 1.89 so current Cargo dependencies can compile.

## Background

MDE can be installed automatically through the `MDE.Linux` extension while an image is being built. A single early `mdatp` purge is not sufficient: the Azure Guest Agent can reconcile the extension again during the gap between cleanup and image capture. That can leave the package, onboarding/configuration data, install logs, systemd state, extension artifacts, or EICAR test files in the final image and cause LISA/Marketplace validation failures.

The Dynolog build was also using Rust 1.82, while its resolved `textwrap 0.16.4` dependency requires Rust 1.88 or newer.

## Changes

### MDATP cleanup

- Stops `walinuxagent`/`waagent` before the initial cleanup and again in the epilog to prevent MDE extension reconciliation during the capture window.
- Purges both `mdatp` and `microsoft-mdatp` package states on Ubuntu and RPM-based images.
- Repeats the purge immediately before image capture as a final backstop.
- Removes MDE-specific program, state, configuration, onboarding, log, audit, AppArmor, systemd, dpkg metadata, and extension residue.
- Removes EICAR test artifacts (`eicar.com*` and `utils_58.py`) without crossing into mounted data disks.
- Reloads systemd after removing unit files.
- Adds `verify_final_cleanup`, which blocks image capture if package state, dpkg metadata, the executable or service, a running `wdavdaemon`, MDE filesystem/extension residue, or EICAR artifacts remain.

Cleanup is intentionally limited to MDE-specific paths rather than broad Microsoft parent directories that may contain files owned by other products.

### Dynolog

- Installs Rust and Cargo 1.89 on Ubuntu.
- Uses a single `RUST_VERSION` value for package selection and the toolchain `PATH`.

## Scope

This PR no longer changes direct `dpkg -i` calls or dpkg/APT lock handling.

## Validation

- `git diff --check` passes.
- Bash syntax validation passes for the three changed scripts.
- The final PR diff is limited to the two MDATP cleanup scripts and the Dynolog installer.